### PR TITLE
fix: resolve Netlify preview build and blank screen

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "pip install pyyaml && npm run build"
   publish = "dist"
 
 [build.environment]

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vite.dev/config/
+const isNetlify = process.env.NETLIFY === "true";
+
 export default defineConfig({
   plugins: [react()],
-  base: "/du-event-board/",
+  base: isNetlify ? "/" : "/du-event-board/",
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION

## Pull Request description

Issue 1 — Build failure:
Netlify build was failing because generate_events_json.py needs pyyaml, which was not installed, causing a ModuleNotFoundError.

Issue 2 — Blank screen:
The Vite base path was hardcoded for GitHub Pages, so assets failed to load on Netlify, resulting in a blank screen.

Fix:

Installed pyyaml during Netlify build

Made Vite base path dynamic using Netlify environment variable


## How to test these changes

- Open any PR on this repo
- Netlify bot should comment with a working deploy preview URL
- Preview should load correctly with all events visible

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

The GitHub Pages deployment is unaffected — `NETLIFY` env var is not set there, so `base` stays `/du-event-board/` as before.

## Screenshorts( Before vs After )
Before
<img width="1915" height="1033" alt="image" src="https://github.com/user-attachments/assets/9759aaa0-61f8-481c-85f3-de85d4e79338" />

After
<img width="1917" height="1026" alt="image" src="https://github.com/user-attachments/assets/6a50d090-7fed-40f2-9af3-2612745e8ce9" />


## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved.
