### PR TITLE
Default date filter to upcoming

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,7 @@ export default function App() {
   const [selectedRegion, setSelectedRegion] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("");
 
-  const [dateFilterType, setDateFilterType] = useState("all");
+  const [dateFilterType, setDateFilterType] = useState("upcoming");
   const [customDate, setCustomDate] = useState("");
   const [rangeStart, setRangeStart] = useState("");
   const [rangeEnd, setRangeEnd] = useState("");


### PR DESCRIPTION
## Summary
- Default the date filter to upcoming events on first load

## Test plan
- [ ] Not run (vitest not installed in environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)