### PR TITLE
feat: add share button to event cards to copy event link (fixes #39)

### DIFF
--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -1,4 +1,14 @@
+import { useState } from "react";
+
 export default function EventCard({ event }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleShare() {
+    navigator.clipboard.writeText(event.url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
   const formattedDate = new Date(event.date + "T00:00:00").toLocaleDateString(
     "en-US",
     {
@@ -40,17 +50,28 @@ export default function EventCard({ event }) {
         </div>
       )}
 
-      {event.url && (
-        <a
-          href={event.url}
-          className="event-card__link"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn more
-          <span className="event-card__link-arrow">→</span>
-        </a>
-      )}
+      <div className="event-card__actions">
+        {event.url && (
+          <a
+            href={event.url}
+            className="event-card__link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more
+            <span className="event-card__link-arrow">→</span>
+          </a>
+        )}
+        {event.url && (
+          <button
+            className={`event-card__share-btn${copied ? " event-card__share-btn--copied" : ""}`}
+            onClick={handleShare}
+            aria-label="Copy event link"
+          >
+            {copied ? "✓ Copied!" : "🔗 Share"}
+          </button>
+        )}
+      </div>
     </article>
   );
 }

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -64,7 +64,9 @@ export default function EventCard({ event }) {
         )}
         {event.url && (
           <button
-            className={`event-card__share-btn${copied ? " event-card__share-btn--copied" : ""}`}
+            className={`event-card__share-btn${
+              copied ? " event-card__share-btn--copied" : ""
+            }`}
             onClick={handleShare}
             aria-label="Copy event link"
           >

--- a/src/index.css
+++ b/src/index.css
@@ -646,3 +646,40 @@ body {
     font-size: 1.1rem;
   }
 }
+
+/* ===================================
+   Event Card Actions
+   =================================== */
+.event-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.event-card__share-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-family: var(--font-family);
+  transition: all var(--transition-base);
+}
+
+.event-card__share-btn:hover {
+  border-color: var(--border-accent);
+  color: var(--accent-primary);
+}
+
+.event-card__share-btn--copied {
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #22c55e;
+  background: rgba(34, 197, 94, 0.08);
+}


### PR DESCRIPTION
## Pull Request description

Adds a share button to each event card that copies the event URL to the
clipboard and shows a brief "Copied!" confirmation for 2 seconds.

Closes #39

### Changes made
- Updated `src/components/EventCard.jsx` — added `useState` hook,
  `handleShare` function using `navigator.clipboard.writeText()`, and
  a share button next to the existing "Learn more" link
- Updated `src/index.css` — added styles for the share button and
  copied state, consistent with the existing design system

## How to test these changes

* Run `npm run dev`
* Open the browser at `http://localhost:5173/du-event-board/`
* Click the **🔗 Share** button on any event card
* The event URL should be copied to your clipboard
* The button should change to **✓ Copied!** for 2 seconds then reset
* Paste anywhere to confirm the correct URL was copied

## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.