### PR TITLE
fix: install pyyaml in Netlify build command to fix deploy preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "pip install pyyaml && npm run build"
   publish = "dist"
 
 [build.environment]


### PR DESCRIPTION
## Pull Request description

Fixes the Netlify deploy preview build failure caused by missing `pyyaml` 
module. The build was failing because `scripts/generate_events_json.py` 
imports `yaml` but `pyyaml` was not installed in the Netlify build 
environment.

The fix adds `pip install pyyaml` to the build command in `netlify.toml` 
so it runs before `npm run build`.

### Changes made
- Updated `netlify.toml` — changed build command from `npm run build` 
  to `pip install pyyaml && npm run build`

## How to test these changes

* Open any PR on this repo
* Check the Netlify deploy preview — it should now build successfully
* The deploy preview URL should load the app correctly

## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

The Netlify build log showed this error on all PRs:
```
ModuleNotFoundError: No module named 'yaml'
```
This was happening because `netlify.toml` only had `npm run build` 
but the prebuild script requires `pyyaml` to be installed first.