### PR TITLE
feat(ui): display event capacity in EventCard

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -10,7 +10,7 @@ events:
     region: "Porto Alegre"
     category: "Technology"
     url: "https://example.com/python-poa"
-    capacity: 50  
+    capacity: 50
     tags:
       - python
       - programming
@@ -27,7 +27,7 @@ events:
     region: "São Paulo"
     category: "Technology"
     url: "https://example.com/react-sp"
-    capacity: 30  
+    capacity: 30
     tags:
       - react
       - javascript
@@ -44,7 +44,7 @@ events:
     region: "Curitiba"
     category: "Technology"
     url: "https://example.com/oss-friday-cwb"
-    capacity: 20  
+    capacity: 20
     tags:
       - open-source
       - community

--- a/data/events.yaml
+++ b/data/events.yaml
@@ -10,6 +10,7 @@ events:
     region: "Porto Alegre"
     category: "Technology"
     url: "https://example.com/python-poa"
+    capacity: 50  
     tags:
       - python
       - programming
@@ -26,6 +27,7 @@ events:
     region: "São Paulo"
     category: "Technology"
     url: "https://example.com/react-sp"
+    capacity: 30  
     tags:
       - react
       - javascript
@@ -42,6 +44,7 @@ events:
     region: "Curitiba"
     category: "Technology"
     url: "https://example.com/oss-friday-cwb"
+    capacity: 20  
     tags:
       - open-source
       - community

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -35,6 +35,7 @@ export default function EventCard({ event }) {
       <p className="event-card__description">{event.description}</p>
 
       <div className="event-card__meta">
+        
         <div className="event-card__meta-item">
           <span className="event-card__meta-icon">📅</span>
           <span>{formattedDate}</span>
@@ -47,6 +48,12 @@ export default function EventCard({ event }) {
           <span className="event-card__meta-icon">📍</span>
           <span>{event.location}</span>
         </div>
+        <div className="event-card__meta-item">
+  <span className="event-card__meta-icon">👥</span>
+  <span>
+    {event.capacity != null ? `${event.capacity} spots` : "Unlimited"}
+  </span>
+</div>
       </div>
 
       {event.tags && event.tags.length > 0 && (

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -35,7 +35,6 @@ export default function EventCard({ event }) {
       <p className="event-card__description">{event.description}</p>
 
       <div className="event-card__meta">
-        
         <div className="event-card__meta-item">
           <span className="event-card__meta-icon">📅</span>
           <span>{formattedDate}</span>
@@ -49,11 +48,11 @@ export default function EventCard({ event }) {
           <span>{event.location}</span>
         </div>
         <div className="event-card__meta-item">
-  <span className="event-card__meta-icon">👥</span>
-  <span>
-    {event.capacity != null ? `${event.capacity} spots` : "Unlimited"}
-  </span>
-</div>
+          <span className="event-card__meta-icon">👥</span>
+          <span>
+            {event.capacity != null ? `${event.capacity} spots` : "Unlimited"}
+          </span>
+        </div>
       </div>
 
       {event.tags && event.tags.length > 0 && (

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -11,6 +11,7 @@
     "region": "Porto Alegre",
     "category": "Technology",
     "url": "https://example.com/python-poa",
+    "capacity": 50,
     "tags": [
       "python",
       "programming",
@@ -29,6 +30,7 @@
     "region": "São Paulo",
     "category": "Technology",
     "url": "https://example.com/react-sp",
+    "capacity": 30,
     "tags": [
       "react",
       "javascript",
@@ -47,6 +49,7 @@
     "region": "Curitiba",
     "category": "Technology",
     "url": "https://example.com/oss-friday-cwb",
+    "capacity": 20,
     "tags": [
       "open-source",
       "community",


### PR DESCRIPTION
## Pull Request description

🔗 Dependencies: https://github.com/data-umbrella/event-board/pull/2

This PR adds frontend support for the optional `capacity` field in events.

It displays:
- The number of available spots when capacity is defined
- "Unlimited" when no capacity is provided

## How to test these changes

- Run `npm install`
- Run `npm run dev`
- Open http://localhost:5173/du-event-board/
- Verify that each event card displays:
  - Capacity (e.g., "50 spots") when defined
  - "Unlimited" when no capacity is set

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

This complements the backend implementation that introduces the `capacity` field in the Event model and API.