### PR TITLE
fix(ci): correct validate-events JSON sync check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,13 +97,21 @@ jobs:
       - name: Install PyYAML
         run: pip install pyyaml
 
-      - name: Validate and generate events
+      - name: Backup committed events.json
+        run: cp src/data/events.json src/data/events.json.committed
+
+      - name: Validate and re-generate events.json
         run: python scripts/generate_events_json.py
 
       - name: Verify generated JSON matches committed JSON
         run: |
-          if ! diff -q src/data/events.json src/data/events.json.bak 2>/dev/null; then
-            echo "✅ events.json generated successfully"
+          if diff -q src/data/events.json src/data/events.json.committed > /dev/null; then
+            echo "✅ events.json is up to date"
+          else
+            echo "❌ events.json is out of sync with events.yaml!"
+            echo "Please run 'npm run generate' and commit the updated src/data/events.json"
+            diff src/data/events.json src/data/events.json.committed
+            exit 1
           fi
 
   semantic-pr-title:


### PR DESCRIPTION
## Pull Request description

The `validate-events` CI job contained a no-op check that always passed,
regardless of whether `src/data/events.json` was actually in sync with
`data/events.yaml`.

**Root cause:** The verification step diffed `events.json` against
`events.json.bak` — a file that is never created anywhere in the workflow.
`diff` always returned non-zero (file not found), the `if !` branch always
caught it, and CI always printed success.

This meant a contributor could edit `events.yaml`, forget to run
`npm run generate`, and open a PR with a stale `events.json` — CI would
pass silently, leaving mentors to catch it manually during review.

**Fix:** Replace the broken step with a proper 3-step check:
1. **Backup** the committed `events.json` before generation.
2. **Re-generate** `events.json` from `events.yaml` via the existing script.
3. **Diff** the regenerated file against the backup — fail with `exit 1`
   and a clear actionable error message if they differ.

Closes #<!-- issue number if applicable -->

## How to test these changes

- Open a test PR that modifies `data/events.yaml` but does **not** run
  `npm run generate` or commit the updated `src/data/events.json`.
- The `validate-events` CI job should now **fail** with:

❌ events.json is out of sync with events.yaml! Please run 'npm run generate' and commit the updated src/data/events.json

- Conversely, a PR that correctly commits the regenerated JSON should pass .

## Pull Request checklists

This PR is a - [x] bug-fix

About this PR:

- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
    complexity.
- [x] New and old tests passed locally.

## Additional information

### Before (broken)
```yaml
- name: Validate and generate events
run: python scripts/generate_events_json.py

- name: Verify generated JSON matches committed JSON
run: |
  if ! diff -q src/data/events.json src/data/events.json.bak 2>/dev/null; then
    echo " events.json generated successfully"
  fi
events.json.bak never exists → diff always "fails" → if ! always prints → always a false green.


- name: Backup committed events.json
  run: cp src/data/events.json src/data/events.json.committed

- name: Validate and re-generate events.json
  run: python scripts/generate_events_json.py

- name: Verify generated JSON matches committed JSON
  run: |
    if diff -q src/data/events.json src/data/events.json.committed > /dev/null; then
      echo "✅ events.json is up to date"
    else
      echo "❌ events.json is out of sync with events.yaml!"
      echo "Please run 'npm run generate' and commit the updated src/data/events.json"
      diff src/data/events.json src/data/events.json.committed
      exit 1
    fi