### PR TITLE
feat: restructuring app.jsx into smaller, readable files

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,168 +1,53 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState } from "react";
 import Header from "./components/Header";
 import SearchBar from "./components/SearchBar";
 import EventCard from "./components/EventCard";
 import EventMap from "./components/EventMap";
+import ResultsHeader from "./components/ResultsHeader";
+import EmptyState from "./components/EmptyState";
 import events from "./data/events.json";
 import { useUrlState } from "./hooks/useUrlState";
-
-function parseISODate(dateString) {
-  if (!dateString) return null;
-  const [year, month, day] = dateString.split("-").map(Number);
-  if (!year || !month || !day) return null;
-  return new Date(year, month - 1, day);
-}
-
-function startOfDay(date) {
-  const normalized = new Date(date);
-  normalized.setHours(0, 0, 0, 0);
-  return normalized;
-}
+import { useTheme } from "./hooks/useTheme";
+import { useEventFilters } from "./hooks/useEventFilters";
+import { useMemo } from "react";
 
 export default function App() {
+  // URL-synced filter state (unchanged behaviour)
   const [searchTerm, setSearchTerm] = useUrlState("search", "");
   const [selectedRegion, setSelectedRegion] = useUrlState("region", "");
   const [selectedCategory, setSelectedCategory] = useUrlState("category", "");
   const [viewMode, setViewMode] = useUrlState("view", "list");
-
   const [dateFilterType, setDateFilterType] = useUrlState("dateType", "all");
   const [customDate, setCustomDate] = useUrlState("customDate", "");
   const [rangeStart, setRangeStart] = useUrlState("rangeStart", "");
   const [rangeEnd, setRangeEnd] = useUrlState("rangeEnd", "");
 
-  const [theme, setTheme] = useState(() => {
-    // Check if we are in a browser and if localStorage.getItem actually exists
-    if (
-      typeof window !== "undefined" &&
-      window.localStorage &&
-      typeof window.localStorage.getItem === "function"
-    ) {
-      return localStorage.getItem("theme") || "dark";
-    }
-    return "dark";
-  });
+  // Theme (extracted to hook)
+  const { theme, toggleTheme } = useTheme();
 
-  useEffect(() => {
-    if (theme === "light") {
-      document.body.classList.add("light-theme");
-    } else {
-      document.body.classList.remove("light-theme");
-    }
-
-    // This line "records" the choice in the browser
-    if (typeof localStorage !== "undefined" && localStorage.setItem) {
-      localStorage.setItem("theme", theme);
-    }
-  }, [theme]);
-
-  const toggleTheme = () =>
-    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
-
+  // Resets related URL state when date filter type changes
+  // (kept in App.jsx because it coordinates multiple URL state setters)
   const handleDateFilterTypeChange = (nextType) => {
     setDateFilterType(nextType);
-
-    if (nextType !== "customDate") {
-      setCustomDate("");
-    }
-
+    if (nextType !== "customDate") setCustomDate("");
     if (nextType !== "customRange") {
       setRangeStart("");
       setRangeEnd("");
     }
   };
 
-  const regions = useMemo(() => {
-    const unique = [...new Set(events.map((e) => e.region))];
-    return unique.sort();
-  }, []);
+  // Derived lists for dropdowns
+  const regions = useMemo(
+    () => [...new Set(events.map((e) => e.region))].sort(),
+    [],
+  );
+  const categories = useMemo(
+    () => [...new Set(events.map((e) => e.category))].sort(),
+    [],
+  );
 
-  const categories = useMemo(() => {
-    const unique = [...new Set(events.map((e) => e.category))];
-    return unique.sort();
-  }, []);
-
-  const filteredEvents = useMemo(() => {
-    const term = searchTerm.toLowerCase().trim();
-
-    const today = startOfDay(new Date());
-
-    const weekStart = new Date(today);
-    const dayIndex = (today.getDay() + 6) % 7;
-    weekStart.setDate(today.getDate() - dayIndex);
-
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekStart.getDate() + 6);
-
-    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
-    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-    monthEnd.setHours(0, 0, 0, 0);
-
-    const selectedCustomDate = parseISODate(customDate);
-    const selectedRangeStart = parseISODate(rangeStart);
-    const selectedRangeEnd = parseISODate(rangeEnd);
-
-    return events.filter((event) => {
-      const eventDate = parseISODate(event.date);
-      if (!eventDate) return false;
-
-      // Text search: title, description, tags
-      const matchesSearch =
-        !term ||
-        event.title.toLowerCase().includes(term) ||
-        event.description.toLowerCase().includes(term) ||
-        (event.tags &&
-          event.tags.some((tag) => tag.toLowerCase().includes(term)));
-
-      // Region filter
-      const matchesRegion = !selectedRegion || event.region === selectedRegion;
-
-      // Category filter
-      const matchesCategory =
-        !selectedCategory || event.category === selectedCategory;
-
-      // Date filter
-      let matchesDate = true;
-
-      switch (dateFilterType) {
-        case "upcoming":
-          matchesDate = eventDate >= today;
-          break;
-        case "thisWeek":
-          matchesDate = eventDate >= weekStart && eventDate <= weekEnd;
-          break;
-        case "thisMonth":
-          matchesDate = eventDate >= monthStart && eventDate <= monthEnd;
-          break;
-        case "customDate":
-          matchesDate =
-            !selectedCustomDate ||
-            eventDate.getTime() === selectedCustomDate.getTime();
-          break;
-        case "customRange":
-          if (
-            selectedRangeStart &&
-            selectedRangeEnd &&
-            selectedRangeStart > selectedRangeEnd
-          ) {
-            matchesDate = false;
-            break;
-          }
-
-          if (selectedRangeStart && eventDate < selectedRangeStart) {
-            matchesDate = false;
-          }
-
-          if (selectedRangeEnd && eventDate > selectedRangeEnd) {
-            matchesDate = false;
-          }
-          break;
-        default:
-          matchesDate = true;
-      }
-
-      return matchesSearch && matchesRegion && matchesCategory && matchesDate;
-    });
-  }, [
+  // Filtering logic (extracted to hook)
+  const filteredEvents = useEventFilters(events, {
     searchTerm,
     selectedRegion,
     selectedCategory,
@@ -170,7 +55,7 @@ export default function App() {
     customDate,
     rangeStart,
     rangeEnd,
-  ]);
+  });
 
   return (
     <>
@@ -194,114 +79,11 @@ export default function App() {
         categories={categories}
       />
       <main className="main" id="main-content">
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: "1.5rem",
-            paddingLeft: "0.25rem",
-          }}
-        >
-          <p
-            className="main__results-info"
-            style={{ marginBottom: 0, paddingLeft: 0 }}
-          >
-            Showing{" "}
-            <span className="main__results-count">
-              {filteredEvents.length}
-            </span>{" "}
-            event{filteredEvents.length !== 1 ? "s" : ""}
-          </p>
-
-          <div
-            className="view-toggle"
-            style={{
-              display: "flex",
-              gap: "0.5rem",
-              background: "var(--bg-input)",
-              padding: "0.3rem",
-              borderRadius: "12px",
-              border: "1px solid var(--border-subtle)",
-            }}
-          >
-            <button
-              onClick={() => setViewMode("list")}
-              style={{
-                padding: "0.5rem 1rem",
-                borderRadius: "8px",
-                background:
-                  viewMode === "list"
-                    ? "var(--accent-primary)"
-                    : "transparent",
-                color: viewMode === "list" ? "#fff" : "var(--text-muted)",
-                border: "none",
-                cursor: "pointer",
-                fontSize: "13px",
-                fontWeight: "bold",
-                transition: "all 0.2s",
-                display: "flex",
-                alignItems: "center",
-                gap: "6px",
-              }}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <line x1="8" y1="6" x2="21" y2="6"></line>
-                <line x1="8" y1="12" x2="21" y2="12"></line>
-                <line x1="8" y1="18" x2="21" y2="18"></line>
-                <line x1="3" y1="6" x2="3.01" y2="6"></line>
-                <line x1="3" y1="12" x2="3.01" y2="12"></line>
-                <line x1="3" y1="18" x2="3.01" y2="18"></line>
-              </svg>
-              List
-            </button>
-            <button
-              onClick={() => setViewMode("map")}
-              style={{
-                padding: "0.5rem 1rem",
-                borderRadius: "8px",
-                background:
-                  viewMode === "map" ? "var(--accent-primary)" : "transparent",
-                color: viewMode === "map" ? "#fff" : "var(--text-muted)",
-                border: "none",
-                cursor: "pointer",
-                fontSize: "13px",
-                fontWeight: "bold",
-                transition: "all 0.2s",
-                display: "flex",
-                alignItems: "center",
-                gap: "6px",
-              }}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21"></polygon>
-                <line x1="9" y1="3" x2="9" y2="21"></line>
-                <line x1="15" y1="3" x2="15" y2="21"></line>
-              </svg>
-              Map
-            </button>
-          </div>
-        </div>
+        <ResultsHeader
+          count={filteredEvents.length}
+          viewMode={viewMode}
+          onViewChange={setViewMode}
+        />
 
         {viewMode === "list" ? (
           <div className="events-grid" id="events-grid">
@@ -310,14 +92,7 @@ export default function App() {
                 <EventCard key={event.id} event={event} />
               ))
             ) : (
-              <div className="empty-state" id="empty-state">
-                <div className="empty-state__icon">🔎</div>
-                <h2 className="empty-state__title">No events found</h2>
-                <p className="empty-state__description">
-                  Try adjusting your search terms or filters to find events
-                  near you.
-                </p>
-              </div>
+              <EmptyState />
             )}
           </div>
         ) : (

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,0 +1,12 @@
+// src/components/EmptyState.jsx
+export default function EmptyState() {
+  return (
+    <div className="empty-state" id="empty-state">
+      <div className="empty-state__icon">🔎</div>
+      <h2 className="empty-state__title">No events found</h2>
+      <p className="empty-state__description">
+        Try adjusting your search terms or filters to find events near you.
+      </p>
+    </div>
+  );
+}

--- a/src/components/ResultsHeader.jsx
+++ b/src/components/ResultsHeader.jsx
@@ -1,0 +1,25 @@
+// src/components/ResultsHeader.jsx
+import ViewToggle from "./ViewToggle";
+
+export default function ResultsHeader({ count, viewMode, onViewChange }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginBottom: "1.5rem",
+        paddingLeft: "0.25rem",
+      }}
+    >
+      <p
+        className="main__results-info"
+        style={{ marginBottom: 0, paddingLeft: 0 }}
+      >
+        Showing <span className="main__results-count">{count}</span> event
+        {count !== 1 ? "s" : ""}
+      </p>
+      <ViewToggle viewMode={viewMode} onViewChange={onViewChange} />
+    </div>
+  );
+}

--- a/src/components/ViewToggle.jsx
+++ b/src/components/ViewToggle.jsx
@@ -1,0 +1,90 @@
+// src/components/ViewToggle.jsx
+export default function ViewToggle({ viewMode, onViewChange }) {
+  return (
+    <div
+      className="view-toggle"
+      style={{
+        display: "flex",
+        gap: "0.5rem",
+        background: "var(--bg-input)",
+        padding: "0.3rem",
+        borderRadius: "12px",
+        border: "1px solid var(--border-subtle)",
+      }}
+    >
+      <button
+        onClick={() => onViewChange("list")}
+        style={{
+          padding: "0.5rem 1rem",
+          borderRadius: "8px",
+          background:
+            viewMode === "list" ? "var(--accent-primary)" : "transparent",
+          color: viewMode === "list" ? "#fff" : "var(--text-muted)",
+          border: "none",
+          cursor: "pointer",
+          fontSize: "13px",
+          fontWeight: "bold",
+          transition: "all 0.2s",
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="8" y1="6" x2="21" y2="6" />
+          <line x1="8" y1="12" x2="21" y2="12" />
+          <line x1="8" y1="18" x2="21" y2="18" />
+          <line x1="3" y1="6" x2="3.01" y2="6" />
+          <line x1="3" y1="12" x2="3.01" y2="12" />
+          <line x1="3" y1="18" x2="3.01" y2="18" />
+        </svg>
+        List
+      </button>
+      <button
+        onClick={() => onViewChange("map")}
+        style={{
+          padding: "0.5rem 1rem",
+          borderRadius: "8px",
+          background:
+            viewMode === "map" ? "var(--accent-primary)" : "transparent",
+          color: viewMode === "map" ? "#fff" : "var(--text-muted)",
+          border: "none",
+          cursor: "pointer",
+          fontSize: "13px",
+          fontWeight: "bold",
+          transition: "all 0.2s",
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
+          <line x1="9" y1="3" x2="9" y2="21" />
+          <line x1="15" y1="3" x2="15" y2="21" />
+        </svg>
+        Map
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useEventFilters.js
+++ b/src/hooks/useEventFilters.js
@@ -1,0 +1,103 @@
+// src/hooks/useEventFilters.js
+import { useMemo } from "react";
+import { parseISODate, startOfDay } from "../utils/date";
+
+export function useEventFilters(
+  events,
+  {
+    searchTerm,
+    selectedRegion,
+    selectedCategory,
+    dateFilterType,
+    customDate,
+    rangeStart,
+    rangeEnd,
+  },
+) {
+  return useMemo(() => {
+    const term = searchTerm.toLowerCase().trim();
+    const today = startOfDay(new Date());
+
+    // Week: Monday → Sunday (matches original logic)
+    const weekStart = new Date(today);
+    const dayIndex = (today.getDay() + 6) % 7; // 0=Mon, 6=Sun
+    weekStart.setDate(today.getDate() - dayIndex);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+
+    // Month: 1st → last day of current month (matches original logic)
+    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    monthEnd.setHours(0, 0, 0, 0);
+
+    const selectedCustomDate = parseISODate(customDate);
+    const selectedRangeStart = parseISODate(rangeStart);
+    const selectedRangeEnd = parseISODate(rangeEnd);
+
+    return events.filter((event) => {
+      const eventDate = parseISODate(event.date);
+      if (!eventDate) return false;
+
+      // Text search
+      const matchesSearch =
+        !term ||
+        event.title.toLowerCase().includes(term) ||
+        event.description.toLowerCase().includes(term) ||
+        (event.tags &&
+          event.tags.some((tag) => tag.toLowerCase().includes(term)));
+
+      // Region
+      const matchesRegion = !selectedRegion || event.region === selectedRegion;
+
+      // Category
+      const matchesCategory =
+        !selectedCategory || event.category === selectedCategory;
+
+      // Date
+      let matchesDate = true;
+      switch (dateFilterType) {
+        case "upcoming":
+          matchesDate = eventDate >= today;
+          break;
+        case "thisWeek":
+          matchesDate = eventDate >= weekStart && eventDate <= weekEnd;
+          break;
+        case "thisMonth":
+          matchesDate = eventDate >= monthStart && eventDate <= monthEnd;
+          break;
+        case "customDate":
+          matchesDate =
+            !selectedCustomDate ||
+            eventDate.getTime() === selectedCustomDate.getTime();
+          break;
+        case "customRange":
+          if (
+            selectedRangeStart &&
+            selectedRangeEnd &&
+            selectedRangeStart > selectedRangeEnd
+          ) {
+            matchesDate = false;
+            break;
+          }
+          if (selectedRangeStart && eventDate < selectedRangeStart)
+            matchesDate = false;
+          if (selectedRangeEnd && eventDate > selectedRangeEnd)
+            matchesDate = false;
+          break;
+        default:
+          matchesDate = true;
+      }
+
+      return matchesSearch && matchesRegion && matchesCategory && matchesDate;
+    });
+  }, [
+    events,
+    searchTerm,
+    selectedRegion,
+    selectedCategory,
+    dateFilterType,
+    customDate,
+    rangeStart,
+    rangeEnd,
+  ]);
+}

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,33 @@
+// src/hooks/useTheme.js
+import { useState, useEffect } from "react";
+
+export function useTheme() {
+  const [theme, setTheme] = useState(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.localStorage &&
+      typeof window.localStorage.getItem === "function"
+    ) {
+      return localStorage.getItem("theme") || "dark"; // default: dark
+    }
+    return "dark";
+  });
+
+  useEffect(() => {
+    // Matches original: toggle "light-theme" class on body
+    if (theme === "light") {
+      document.body.classList.add("light-theme");
+    } else {
+      document.body.classList.remove("light-theme");
+    }
+
+    if (typeof localStorage !== "undefined" && localStorage.setItem) {
+      localStorage.setItem("theme", theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+
+  return { theme, toggleTheme };
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,19 @@
+/**
+ * Parses "YYYY-MM-DD" as a local midnight date,
+ * avoiding UTC timezone shift bugs.
+ */
+export function parseISODate(dateString) {
+  if (!dateString) return null;
+  const [year, month, day] = dateString.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+}
+
+/**
+ * Returns the given date set to 00:00:00.000 (midnight).
+ */
+export function startOfDay(date) {
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+}


### PR DESCRIPTION
## Pull Request description

The current App.jsx file has grown large and handles multiple responsibilities, including :

- UI rendering
- Filtering logic
- State management (search, filters, theme, view)
- Utility functions (date parsing, normalization)

This makes the file harder to read, maintain, and extend.

Refactored App.jsx by separating concerns into smaller, reusable components and hooks to improve code readability, maintainability, and structure.

Solving issue #83 


## How to test these changes

- Run `npm install` then `npm run generate` then `npm run dev`
- Open the browser at `localhost:5173`
- All functionalities work as expected
- code base is restructured

## New Project Structure

```
.
├── CODE_OF_CONDUCT.md
├── conda.yaml
├── CONTRIBUTING.md
├── data
│   └── events.yaml
├── eslint.config.js
├── index.html
├── LICENSE
├── netlify.toml
├── package-lock.json
├── package.json
├── public
│   ├── DU_logo.png
│   └── vite.svg
├── pyproject.toml
├── README.md
├── scripts
│   └── generate_events_json.py
├── src
│   ├── App.jsx
│   ├── components
│   │   ├── EmptyState.jsx
│   │   ├── EventCard.jsx
│   │   ├── EventMap.jsx
│   │   ├── Header.jsx
│   │   ├── ResultsHeader.jsx
│   │   ├── SearchBar.jsx
│   │   └── ViewToggle.jsx
│   ├── data
│   │   └── events.json
│   ├── hooks
│   │   ├── useEventFilters.js
│   │   ├── useTheme.js
│   │   └── useUrlState.js
│   ├── index.css
│   ├── main.jsx
│   ├── test
│   │   ├── App.test.jsx
│   │   └── setup.js
│   └── utils
│       └── date.js
└── vite.config.js
```

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:

- [ ] it includes tests.
- [x] the tests are executed on CI.
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update, regarding file structure.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.


