### PR TITLE
fix(map): resolve triple .find() redundancy and support dynamic themes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -321,7 +321,7 @@ export default function App() {
             )}
           </div>
         ) : (
-          <EventMap events={filteredEvents} />
+          <EventMap events={filteredEvents} theme={theme} />
         )}
       </main>
       <footer className="footer">

--- a/src/components/EventMap.jsx
+++ b/src/components/EventMap.jsx
@@ -16,16 +16,12 @@ L.Icon.Default.mergeOptions({
     "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png",
 });
 
-export default function EventMap({ events }) {
-  // Find center based on first geocoded event or fallback
-  const mapCenter = events.find((e) => e.lat && e.lng)
-    ? [
-        events.find((e) => e.lat && e.lng).lat,
-        events.find((e) => e.lat && e.lng).lng,
-      ]
-    : [-14.235, -51.925]; // Center of Brazil as fallback
+export default function EventMap({ events, theme }) {
+  const firstGeocodedEvent = events.find((e) => e.lat && e.lng);
+  const mapCenter = firstGeocodedEvent
+    ? [firstGeocodedEvent.lat, firstGeocodedEvent.lng]
+    : [-14.235, -51.925];
 
-  // Filter events with valid coords
   const mapEvents = events.filter((e) => e.lat && e.lng);
 
   if (mapEvents.length === 0) {
@@ -68,7 +64,11 @@ export default function EventMap({ events }) {
           }}
         >
           <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+            url={
+              theme === "light"
+                ? "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+                : "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+            }
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
           />
 
@@ -87,7 +87,7 @@ export default function EventMap({ events }) {
                       margin: "0 0 10px 0",
                       fontSize: "1.2rem",
                       fontWeight: "bold",
-                      color: "#111",
+                      color: "var(--text-primary)",
                     }}
                   >
                     {event.title}
@@ -99,7 +99,7 @@ export default function EventMap({ events }) {
                       alignItems: "center",
                       gap: "6px",
                       fontSize: "13px",
-                      color: "#555",
+                      color: "var(--text-secondary)",
                       marginBottom: "12px",
                     }}
                   >
@@ -111,7 +111,7 @@ export default function EventMap({ events }) {
                     style={{
                       fontSize: "14px",
                       margin: "0 0 16px 0",
-                      color: "#333",
+                      color: "var(--text-secondary)",
                       display: "-webkit-box",
                       WebkitLineClamp: 3,
                       WebkitBoxOrient: "vertical",
@@ -131,7 +131,7 @@ export default function EventMap({ events }) {
                       alignItems: "center",
                       gap: "6px",
                       textDecoration: "none",
-                      backgroundColor: "#7c5cfc",
+                      backgroundColor: "var(--accent-primary)",
                       color: "white",
                       padding: "8px 16px",
                       borderRadius: "8px",


### PR DESCRIPTION
## Pull Request description 
- This PR resolves multiple interconnected technical debt and UX bugs located within EventMap.jsx to significantly improve reliability, performance, and UI responsiveness:

1. Performant Centering: Resolved a redundant array search which iterated .find three consecutive times to pull the map's initial [lat, lng] baseline point.
2. Synchronized Tile Theme: EventMap was not previously aware of App.jsx's light/dark mode preference. It now receives the theme prop and seamlessly switches base_maps.cartocdn requests between dark_all and light_all.
3. Harmonized Popup Styling Tokens: Swept away manually hardcoded HEX colors (#111, #333, #555, #7c5cfc) inside the map's inline Popup elements in favor of established design-system variables (var(--text-primary), var(--accent-primary)); directly allowing the light theme to correctly colorize map nodes.

## How to test these changes
• * run `$ npm run dev`
• open the web browser to http://localhost:5173/du-event-board/
• Toggle the light/dark mode icon switcher at the top of the header. The map tile layer should instantly switch base patterns from dark to light.
• Select the "Map" layout, then click on any localized event on the map during "light" mode. It will correctly yield inverted pop-up information boxes instead of static dark overlays.

## Pull Request checklists

This PR is a:
- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
    complexity.
- [x] New and old tests passed locally.

Additional information
Here is a view of the newly synchronized Light Theme map tiles rendering properly, with unified CSS variables enforcing crisp readability against the Popup nodes: 
<img width="1320" height="907" alt="changed map " src="https://github.com/user-attachments/assets/551b320f-e9d5-4351-b6bb-a617d55c6896" />

