### PR TITLE
fix: Replace default Vite favicon with project logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/DU_logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"


### PR DESCRIPTION
## Pull Request description

This PR replaces the default Vite favicon with the project's custom logo.

The application was still using the default `/vite.svg` favicon in `index.html`, despite having a custom logo already used in the UI.

This improves branding consistency and provides a more polished user experience.

---

## How to test these changes

* Run:

  ```
  npm run dev
  ```
* Open the app in browser
* Check the browser tab icon (favicon)
* It should now display the project logo instead of the default Vite icon

---

## Pull Request checklists

This PR is a:

* [x] bug-fix
* [ ] new feature
* [ ] maintenance

About this PR:

* [ ] it includes tests.
* [ ] the tests are executed on CI.
* [x] pre-commit hooks were executed locally.
* [ ] this PR requires a project documentation update.

Author's checklist:

* [x] I have reviewed the changes and it contains no misspelling.
* [x] New and old tests passed locally.

---

## Additional information

This is a small UI/branding fix to replace leftover boilerplate configuration from the initial Vite setup.
