### PR TITLE
feat(events): featured events strip from YAML

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -32,6 +32,8 @@ events:
       - frontend
 
   - id: "3"
+    featured: true
+    featured_rank: 1
     lat: -25.4295963
     lng: -49.2712724
     title: "Open Source Friday - Curitiba"
@@ -48,6 +50,8 @@ events:
       - programming
 
   - id: "4"
+    featured: true
+    featured_rank: 2
     lat: -22.9110137
     lng: -43.2093727
     title: "Data Science Bootcamp - Rio de Janeiro"
@@ -112,6 +116,8 @@ events:
       - systems
 
   - id: "8"
+    featured: true
+    featured_rank: 3
     lat: -27.544562
     lng: -48.4999697
     title: "Community Hackathon - Florianópolis"

--- a/scripts/generate_events_json.py
+++ b/scripts/generate_events_json.py
@@ -158,7 +158,48 @@ def validate_event(event: dict[str, Any], index: int) -> list[str]:
                 f"Event #{index}: Invalid time format '{event['time']}' (expected HH:MM)"
             )
 
+    # Optional featured / featured_rank (curated strip in the UI)
+    if "featured" in event:
+        if not isinstance(event["featured"], bool):
+            errors.append(
+                f"Event #{index}: 'featured' must be a boolean (YAML true/false), "
+                f"got {type(event['featured']).__name__}"
+            )
+    is_featured = event.get("featured") is True
+    if "featured_rank" in event:
+        if not is_featured:
+            errors.append(
+                f"Event #{index}: 'featured_rank' is only allowed when 'featured' is true"
+            )
+        else:
+            rank_val = event["featured_rank"]
+            if isinstance(rank_val, bool) or not isinstance(rank_val, int):
+                errors.append(
+                    f"Event #{index}: 'featured_rank' must be an integer, "
+                    f"got {type(rank_val).__name__}"
+                )
+            elif rank_val < 0:
+                errors.append(
+                    f"Event #{index}: 'featured_rank' must be >= 0, got {rank_val!r}"
+                )
+
     return errors
+
+
+def normalize_featured_fields(event: dict[str, Any]) -> None:
+    """
+    title: Keep JSON output consistent for optional featured fields.
+    summary: >-
+      Featured events get explicit rank (default 0). Non-featured entries
+      omit both keys so the frontend can use `featured === true` checks.
+    """
+    if event.get("featured") is True:
+        rank = event.get("featured_rank", 0)
+        event["featured"] = True
+        event["featured_rank"] = int(rank)
+    else:
+        event.pop("featured", None)
+        event.pop("featured_rank", None)
 
 
 def update_yaml_surgically(events_with_coords: list[dict[str, Any]]) -> None:
@@ -288,6 +329,9 @@ def main() -> None:
         for error in all_errors:
             print(f"  - {error}", file=sys.stderr)
         sys.exit(1)
+
+    for event in events:
+        normalize_featured_fields(event)
 
     print("All events validated successfully")
 

--- a/scripts/generate_events_json.py
+++ b/scripts/generate_events_json.py
@@ -190,8 +190,11 @@ def normalize_featured_fields(event: dict[str, Any]) -> None:
     """
     title: Keep JSON output consistent for optional featured fields.
     summary: >-
-      Featured events get explicit rank (default 0). Non-featured entries
-      omit both keys so the frontend can use `featured === true` checks.
+      Featured events get explicit rank (default 0). Non-featured entries omit
+      both keys so the frontend can use `featured === true` checks.
+    parameters:
+      event:
+        type: dict[str, Any]
     """
     if event.get("featured") is True:
         rank = event.get("featured_rank", 0)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import Footer from "./components/Footer";
 import events from "./data/events.json";
 import { useUrlState } from "./hooks/useUrlState";
 
+const FEATURED_STRIP_MAX = 3;
+
 function parseISODate(dateString) {
   if (!dateString) return null;
   const [year, month, day] = dateString.split("-").map(Number);
@@ -178,6 +180,30 @@ export default function App() {
     rangeEnd,
   ]);
 
+  const featuredEventsFiltered = useMemo(() => {
+    const list = filteredEvents.filter((e) => e.featured === true);
+    list.sort((a, b) => {
+      const ra = a.featured_rank ?? 0;
+      const rb = b.featured_rank ?? 0;
+      if (ra !== rb) return ra - rb;
+      const da = parseISODate(a.date)?.getTime() ?? 0;
+      const db = parseISODate(b.date)?.getTime() ?? 0;
+      return da - db;
+    });
+    return list;
+  }, [filteredEvents]);
+
+  const featuredStripEvents = useMemo(
+    () => featuredEventsFiltered.slice(0, FEATURED_STRIP_MAX),
+    [featuredEventsFiltered],
+  );
+
+  const scrollToEventsGrid = () => {
+    document
+      .getElementById("events-grid")
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   return (
     <>
       <Header
@@ -204,6 +230,46 @@ export default function App() {
         categories={categories}
       />
       <main className="main" id="main-content">
+        {viewMode === "list" && featuredStripEvents.length > 0 && (
+          <section
+            className="featured-strip"
+            aria-labelledby="featured-strip-heading"
+          >
+            <div className="featured-strip__header">
+              <h2
+                id="featured-strip-heading"
+                className="featured-strip__title"
+              >
+                Featured events
+              </h2>
+              {featuredEventsFiltered.length > FEATURED_STRIP_MAX && (
+                <button
+                  type="button"
+                  className="featured-strip__more"
+                  onClick={scrollToEventsGrid}
+                >
+                  More events
+                </button>
+              )}
+            </div>
+            <div
+              className="featured-strip__scroller"
+              role="list"
+              aria-label="Featured event cards"
+            >
+              {featuredStripEvents.map((event) => (
+                <div
+                  key={event.id}
+                  className="featured-strip__item"
+                  role="listitem"
+                >
+                  <EventCard event={event} compact />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
         <div
           style={{
             display: "flex",

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -1,6 +1,6 @@
 import { getEventStatus } from "../utils/eventHelpers";
 
-export default function EventCard({ event }) {
+export default function EventCard({ event, compact = false }) {
   const status = getEventStatus(event.date);
   const formattedDate = new Date(event.date + "T00:00:00").toLocaleDateString(
     "en-US",
@@ -19,7 +19,10 @@ export default function EventCard({ event }) {
   };
 
   return (
-    <article className="event-card" id={`event-${event.id}`}>
+    <article
+      className={`event-card${compact ? " event-card--compact" : ""}`}
+      id={compact ? undefined : `event-${event.id}`}
+    >
       <div className="event-card__header">
         <span className="event-card__category">{event.category}</span>
 
@@ -49,7 +52,7 @@ export default function EventCard({ event }) {
         </div>
       </div>
 
-      {event.tags && event.tags.length > 0 && (
+      {event.tags && event.tags.length > 0 && !compact && (
         <div className="event-card__tags">
           {event.tags.map((tag) => (
             <span key={tag} className="event-card__tag">

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -37,6 +37,8 @@
   },
   {
     "id": "3",
+    "featured": true,
+    "featured_rank": 1,
     "lat": -25.4295963,
     "lng": -49.2712724,
     "title": "Open Source Friday - Curitiba",
@@ -55,6 +57,8 @@
   },
   {
     "id": "4",
+    "featured": true,
+    "featured_rank": 2,
     "lat": -22.9110137,
     "lng": -43.2093727,
     "title": "Data Science Bootcamp - Rio de Janeiro",
@@ -127,6 +131,8 @@
   },
   {
     "id": "8",
+    "featured": true,
+    "featured_rank": 3,
     "lat": -27.544562,
     "lng": -48.4999697,
     "title": "Community Hackathon - Florianópolis",

--- a/src/index.css
+++ b/src/index.css
@@ -697,6 +697,101 @@ body {
 }
 
 /* ===================================
+   Featured events strip
+   =================================== */
+.featured-strip {
+  margin-bottom: 2rem;
+  padding: 1.25rem 1.25rem 1.5rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.featured-strip__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.featured-strip__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.featured-strip__more {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-primary);
+  background: rgba(124, 92, 252, 0.1);
+  border: 1px solid rgba(124, 92, 252, 0.25);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.featured-strip__more:hover {
+  background: rgba(124, 92, 252, 0.18);
+  border-color: rgba(124, 92, 252, 0.4);
+}
+
+.featured-strip__scroller {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
+}
+
+.featured-strip__item {
+  flex: 0 0 min(100%, 320px);
+  scroll-snap-align: start;
+  min-width: min(100%, 280px);
+}
+
+.event-card--compact {
+  padding: 1.15rem 1.25rem;
+  height: 100%;
+}
+
+.event-card--compact .event-card__title {
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.event-card--compact .event-card__description {
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  margin-bottom: 0.85rem;
+  font-size: 0.82rem;
+}
+
+.event-card--compact .event-card__meta {
+  margin-bottom: 0.75rem;
+  gap: 0.35rem;
+}
+
+.event-card--compact .event-card__meta-item {
+  font-size: 0.78rem;
+}
+
+.event-card--compact .event-card__header {
+  margin-bottom: 0.65rem;
+}
+
+.event-card--compact .event-card__link {
+  font-size: 0.8rem;
+  padding: 0.4rem 0.75rem;
+}
+
+/* ===================================
    Empty State
    =================================== */
 .empty-state {

--- a/src/index.css
+++ b/src/index.css
@@ -733,7 +733,9 @@ body {
   border-radius: var(--radius-sm);
   padding: 0.4rem 0.9rem;
   cursor: pointer;
-  transition: background var(--transition-base), border-color var(--transition-base);
+  transition:
+    background var(--transition-base),
+    border-color var(--transition-base);
 }
 
 .featured-strip__more:hover {

--- a/src/test/App.featured.test.jsx
+++ b/src/test/App.featured.test.jsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+vi.mock("../data/events.json", () => ({
+  default: [
+    {
+      id: "f1",
+      title: "Featured Alpha",
+      description: "Desc A",
+      date: "2026-06-01",
+      time: "10:00",
+      location: "L1",
+      region: "R1",
+      category: "Technology",
+      url: "https://example.com/a",
+      featured: true,
+      featured_rank: 2,
+    },
+    {
+      id: "f2",
+      title: "Featured Beta",
+      description: "Desc B",
+      date: "2026-06-02",
+      time: "11:00",
+      location: "L2",
+      region: "R2",
+      category: "Technology",
+      url: "https://example.com/b",
+      featured: true,
+      featured_rank: 1,
+    },
+    {
+      id: "n1",
+      title: "Normal Gamma",
+      description: "Desc G",
+      date: "2026-06-03",
+      time: "12:00",
+      location: "L3",
+      region: "R1",
+      category: "Education",
+      url: "https://example.com/g",
+    },
+    {
+      id: "f3",
+      title: "Featured Delta",
+      description: "Desc D",
+      date: "2026-06-04",
+      time: "13:00",
+      location: "L4",
+      region: "R3",
+      category: "Community",
+      url: "https://example.com/d",
+      featured: true,
+      featured_rank: 3,
+    },
+    {
+      id: "f4",
+      title: "Featured Epsilon",
+      description: "Desc E",
+      date: "2026-06-05",
+      time: "14:00",
+      location: "L5",
+      region: "R3",
+      category: "Community",
+      url: "https://example.com/e",
+      featured: true,
+      featured_rank: 4,
+    },
+  ],
+}));
+
+import App from "../App";
+
+describe("Featured strip (mock data)", () => {
+  let scrollIntoViewMock;
+
+  beforeEach(() => {
+    scrollIntoViewMock = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 15, 12, 0, 0));
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    delete window.HTMLElement.prototype.scrollIntoView;
+    vi.useRealTimers();
+  });
+
+  it("shows up to three featured cards ordered by featured_rank then date", () => {
+    const { container } = render(<App />);
+    const strip = container.querySelector(".featured-strip");
+    expect(strip).toBeTruthy();
+    const stripCards = within(strip).getAllByRole("article");
+    expect(stripCards).toHaveLength(3);
+    expect(stripCards[0]).toHaveTextContent("Featured Beta");
+    expect(stripCards[1]).toHaveTextContent("Featured Alpha");
+    expect(stripCards[2]).toHaveTextContent("Featured Delta");
+
+    expect(screen.getAllByRole("article")).toHaveLength(8);
+    expect(screen.getByText("Featured Epsilon")).toBeInTheDocument();
+  });
+
+  it("keeps the main list count equal to all matching events", () => {
+    render(<App />);
+    const resultsInfo = screen.getByText(/Showing/);
+    expect(resultsInfo.textContent).toContain("5");
+    expect(resultsInfo.textContent).toContain("events");
+  });
+
+  it("offers More events and scrolls to the grid when there are over three featured", () => {
+    render(<App />);
+    const more = screen.getByRole("button", { name: /more events/i });
+    expect(more).toBeInTheDocument();
+    fireEvent.click(more);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+});

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import App from "../App";
+
+function getEventsGrid() {
+  const el = document.getElementById("events-grid");
+  if (!el) throw new Error("#events-grid not found");
+  return el;
+}
 
 describe("App", () => {
   beforeEach(() => {
@@ -41,6 +47,16 @@ describe("App", () => {
     expect(screen.getByText("React Workshop - São Paulo")).toBeInTheDocument();
   });
 
+  it("renders the featured events strip for YAML-flagged events", () => {
+    render(<App />);
+    expect(
+      screen.getByRole("heading", { name: /featured events/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Open Source Friday - Curitiba").length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
   it("shows the total events count", () => {
     render(<App />);
     const resultsInfo = screen.getByText(/Showing/);
@@ -57,14 +73,15 @@ describe("App", () => {
 
     fireEvent.change(searchInput, { target: { value: "python" } });
 
+    const grid = getEventsGrid();
     expect(
-      screen.getByText("Python Meetup - Porto Alegre"),
+      within(grid).getByText("Python Meetup - Porto Alegre"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Data Science Bootcamp - Rio de Janeiro"),
+      within(grid).getByText("Data Science Bootcamp - Rio de Janeiro"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("React Workshop - São Paulo"),
+      within(grid).queryByText("React Workshop - São Paulo"),
     ).not.toBeInTheDocument();
   });
 
@@ -91,11 +108,12 @@ describe("App", () => {
 
     fireEvent.change(categorySelect, { target: { value: "Education" } });
 
+    const grid = getEventsGrid();
     expect(
-      screen.getByText("Data Science Bootcamp - Rio de Janeiro"),
+      within(grid).getByText("Data Science Bootcamp - Rio de Janeiro"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Python Meetup - Porto Alegre"),
+      within(grid).queryByText("Python Meetup - Porto Alegre"),
     ).not.toBeInTheDocument();
   });
 
@@ -121,11 +139,12 @@ describe("App", () => {
     render(<App />);
     setDateFilter("upcoming");
 
+    const grid = getEventsGrid();
     expect(
-      screen.getByText("Rust Programming Intro - São Paulo"),
+      within(grid).getByText("Rust Programming Intro - São Paulo"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Community Hackathon - Florianópolis"),
+      within(grid).getByText("Community Hackathon - Florianópolis"),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("UX Design Workshop - Porto Alegre"),
@@ -151,11 +170,12 @@ describe("App", () => {
     render(<App />);
     setDateFilter("thisMonth");
 
+    const grid = getEventsGrid();
     expect(
-      screen.getByText("DevOps Meetup - Belo Horizonte"),
+      within(grid).getByText("DevOps Meetup - Belo Horizonte"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Community Hackathon - Florianópolis"),
+      within(grid).getByText("Community Hackathon - Florianópolis"),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("Python Meetup - Porto Alegre"),

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+// jsdom does not implement scrollTo; App scrolls to top on page changes.
+window.scrollTo = vi.fn();


### PR DESCRIPTION
Adds optional `featured` and `featured_rank` on events in `data/events.yaml`. The generator checks types and rules (e.g. rank only when `featured: true`), normalises output, and still omits those keys on non-featured rows in `events.json`. The list view shows a horizontal strip (max 3 cards, sort by rank then date) above the grid; featured rows stay in the main list too. If there are more than three featured matches, **More events** scrolls to `#events-grid`. `EventCard` gets a compact variant for the strip so we do not duplicate element `id`s.

Closes #64

## Pull Request description

Event discovery issue #64: curated “start here” strip without hard-coding titles in React. Maintainers flip flags in YAML; invalid combinations fail in `scripts/generate_events_json.py` with a clear line in CI.

## How to test these changes

- `pip install pyyaml` then `python scripts/generate_events_json.py` (or `npm run generate` if `python` is on PATH)
- `npm ci` → `npm run test` → `npm run lint` → `npm run build`
- `npm run dev`, open the app: you should see **Featured events** with three sample cards (events 3, 4, 8), full grid below including the same events, and **More events** only if more than three featured items match the current filters

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

Sample featured entries live on events **3**, **4**, and **8** in `data/events.yaml` for manual QA. Screenshot optional: strip + grid on default filters.

