### PR TITLE
fix: prevent start date from being after end date in custom range

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -16,6 +16,12 @@ export default function SearchBar({
   regions,
   categories,
 }) {
+  const isInvalidRange =
+    dateFilterType === "customRange" &&
+    rangeStart &&
+    rangeEnd &&
+    rangeStart > rangeEnd;
+
   return (
     <div className="search" id="search">
       <div className="search__container">
@@ -128,8 +134,11 @@ export default function SearchBar({
                 onBlur={(e) => {
                   if (!e.target.value) e.target.type = "text";
                 }}
-                className="search__date-input search__select"
+                className={`search__date-input search__select ${
+                  isInvalidRange ? "search__date-input--invalid" : ""
+                }`}
                 value={rangeStart}
+                max={rangeEnd || undefined}
                 onChange={(e) => {
                   if (dateFilterType !== "customRange")
                     onDateFilterTypeChange("customRange");
@@ -154,8 +163,11 @@ export default function SearchBar({
                 onBlur={(e) => {
                   if (!e.target.value) e.target.type = "text";
                 }}
-                className="search__date-input search__select"
+                className={`search__date-input search__select ${
+                  isInvalidRange ? "search__date-input--invalid" : ""
+                }`}
                 value={rangeEnd}
+                min={rangeStart || undefined}
                 onChange={(e) => {
                   if (dateFilterType !== "customRange")
                     onDateFilterTypeChange("customRange");
@@ -164,6 +176,11 @@ export default function SearchBar({
                 aria-label="Range end date"
                 style={{ width: "160px" }}
               />
+              {isInvalidRange && (
+                <div className="search__error-message">
+                  <span>Start date cannot be after end date</span>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -341,6 +341,7 @@ body {
   gap: 0.5rem;
   flex: 1 1 320px;
   min-width: 280px;
+  position: relative; /* Anchor for absolute error message */
 }
 
 .search__date-input {
@@ -362,6 +363,58 @@ body {
   background-color: var(--bg-input-focus);
   border-color: var(--border-accent);
   box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.search__date-input--invalid {
+  border-color: rgba(239, 68, 68, 0.4) !important;
+  background-color: rgba(239, 68, 68, 0.05) !important;
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.2) !important;
+}
+
+.search__error-message {
+  color: #ef4444; /* Standard red for accessibility */
+  font-size: 0.81rem;
+  font-weight: 600;
+  padding: 0.45rem 0.9rem;
+  background: rgba(10, 10, 26, 0.98);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: 8px;
+  backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  position: absolute;
+  top: Calc(100% + 12px);
+  left: 0;
+  z-index: 20;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  opacity: 1; /* Always visible in invalid state */
+  transform: translateY(0);
+}
+
+.search__error-message::before {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: 15px;
+  width: 12px;
+  height: 12px;
+  background: rgba(10, 10, 26, 0.98);
+  border-left: 1px solid rgba(239, 68, 68, 0.4);
+  border-top: 1px solid rgba(239, 68, 68, 0.4);
+  transform: rotate(45deg);
+}
+
+.light-theme .search__error-message {
+  background: rgba(255, 255, 255, 1);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.light-theme .search__error-message::before {
+  background: rgba(255, 255, 255, 1);
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 .search__date-input::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
This PR makes sure that user can't put the end date before the start date while applying filters

<img width="1440" height="538" alt="image" src="https://github.com/user-attachments/assets/e71289e1-2bf4-4516-bdd0-93da449d894f" />



<img width="844" height="175" alt="Screenshot 2026-03-29 at 2 51 24 PM" src="https://github.com/user-attachments/assets/02eaf8f0-93a2-45a9-ab27-211f0ec765d4" />
