### PR TITLE
fix: replace sun and moon icons to correct uneven spacing in theme toggle

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,3 +1,5 @@
+import { MoonIcon, SunIcon } from "lucide-react";
+
 export default function Header({ theme, onToggleTheme, onNavigate }) {
   return (
     <header className="header" id="header">
@@ -16,7 +18,11 @@ export default function Header({ theme, onToggleTheme, onNavigate }) {
           onClick={onToggleTheme}
           aria-label="Toggle Theme"
         >
-          {theme === "dark" ? "☀️" : "🌙"}
+          {theme === "dark" ? (
+            <SunIcon size={16} color="#f2e674" />
+          ) : (
+            <MoonIcon size={16} color="#4a5568" />
+          )}
         </button>
       </div>
 


### PR DESCRIPTION
## Pull Request description

This pull request fixes uneven spacing due to using text icons for the theme toggle instead of an svg or icon element.
Icons from `lucide-react` library have been used to correct this.

fixes #136

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

- Before:
<img width="83" height="58" alt="Screenshot 2026-03-30 204201" src="https://github.com/user-attachments/assets/4cb2e2ed-a3ec-4726-a644-4655c0a16c1c" />
<img width="85" height="59" alt="Screenshot 2026-03-30 204135" src="https://github.com/user-attachments/assets/1e12e359-ae30-4f5d-900f-affc5f39c574" />

- After:
<img width="81" height="56" alt="Screenshot 2026-03-30 203910" src="https://github.com/user-attachments/assets/fcf33b26-261e-4f28-8ea8-f0df1868da6c" />
<img width="89" height="58" alt="Screenshot 2026-03-30 203859" src="https://github.com/user-attachments/assets/5dde7e9b-37ed-444b-8b40-fd5b17c2195f" />


## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved.
```
