### PR TITLE
fix: make python script compatible with Windows (python3 → python fal…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "predev": "python3 scripts/generate_events_json.py",
+    "predev": "python3 scripts/generate_events_json.py || python scripts/generate_events_json.py",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
Fixes a cross-platform compatibility issue where the `predev` script fails on Windows due to use of `python3`.

## Problem
The project uses:
python3 scripts/generate_events_json.py

However, on Windows systems, Python is typically invoked using `python`, which causes the dev server to fail with:
"Python was not found"

## Solution
Updated the script to:
python3 scripts/generate_events_json.py || python scripts/generate_events_json.py

This ensures compatibility across:
- Linux/macOS (python3)
- Windows (python fallback)

## How to Test
1. Run `npm install`
2. Run `npm run dev`
3. Verify that the app starts successfully on Windows without Python errors

## Impact
- Improves developer experience
- Ensures cross-platform compatibility
- Helps new contributors set up the project smoothly

This issue was encountered during initial project setup.