### PR TITLE
test: add unit tests for getEventStatus helper

### DIFF
--- a/src/test/eventHelpers.test.js
+++ b/src/test/eventHelpers.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getEventStatus } from "../utils/eventHelpers";
+
+describe("getEventStatus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 15, 12, 0, 0)); // Apr 15, 2026
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'none' when eventDate is null", () => {
+    expect(getEventStatus(null)).toBe("none");
+  });
+
+  it("returns 'none' when eventDate is undefined", () => {
+    expect(getEventStatus(undefined)).toBe("none");
+  });
+
+  it("returns 'none' when eventDate is an empty string", () => {
+    expect(getEventStatus("")).toBe("none");
+  });
+
+  it("returns 'live' for today's date", () => {
+    expect(getEventStatus("2026-04-15")).toBe("live");
+  });
+
+  it("returns 'upcoming' for tomorrow", () => {
+    expect(getEventStatus("2026-04-16")).toBe("upcoming");
+  });
+
+  it("returns 'upcoming' for a date 2 days away", () => {
+    expect(getEventStatus("2026-04-17")).toBe("upcoming");
+  });
+
+  it("returns 'upcoming' for a date 3 days away", () => {
+    expect(getEventStatus("2026-04-18")).toBe("upcoming");
+  });
+
+  it("returns 'none' for a date 4 days away", () => {
+    expect(getEventStatus("2026-04-19")).toBe("none");
+  });
+
+  it("returns 'none' for a date far in the future", () => {
+    expect(getEventStatus("2026-12-25")).toBe("none");
+  });
+
+  it("returns 'ended' for yesterday", () => {
+    expect(getEventStatus("2026-04-14")).toBe("ended");
+  });
+
+  it("returns 'ended' for a date well in the past", () => {
+    expect(getEventStatus("2025-01-01")).toBe("ended");
+  });
+});


### PR DESCRIPTION
## Summary

Added comprehensive test coverage for the `getEventStatus` utility function in `src/utils/eventHelpers.js`. This function is used across the app to determine if events are live, upcoming, or ended, but had no dedicated tests.

## Changes

- Created `src/test/eventHelpers.test.js` with 11 test cases covering:
  - Null/undefined/empty inputs return `'none'`
  - Today's date returns `'live'`
  - Dates 1-3 days away return `'upcoming'`
  - Dates 4+ days in the future return `'none'`
  - Past dates return `'ended'`

## Testing

All 26 tests pass (15 existing + 11 new):

```
Test Files  2 passed (2)
     Tests  26 passed (26)
```

This improves code reliability as the project grows, especially ahead of the GSoC work on new filtering features.