### PR TITLE
feat: add reset filters button and fix filtering crash issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "predev": "python3 scripts/generate_events_json.py || python scripts/generate_events_json.py",
+    "predev": "python scripts/generate_events_json.py",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "predev": "python3 scripts/generate_events_json.py",
+    "predev": "python3 scripts/generate_events_json.py || python scripts/generate_events_json.py",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -396,7 +396,7 @@ export default function App() {
           ) : (
             <div className="empty-state" id="empty-state">
               <div className="empty-state__icon">🔎</div>
-              <h2 className="empty-state__title">No events match your filters</h2>
+              <h2 className="empty-state__title">No events found</h2>
               <button
                 onClick={resetFilters}
                 style={{
@@ -434,8 +434,7 @@ export default function App() {
           ) : (
             <div className="empty-state" id="empty-state">
               <div className="empty-state__icon">🔎</div>
-              <h2 className="empty-state__title">No events match your filters</h2>
-
+              <h2 className="empty-state__title">No events found</h2>
               <button
                onClick={resetFilters}
                 style={{

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,7 +98,6 @@ export default function App() {
     setRangeEnd("");
   };
 
-
   const filteredEvents = useMemo(() => {
     const term = searchTerm.toLowerCase().trim();
 
@@ -119,24 +118,25 @@ export default function App() {
     const selectedRangeStart = parseISODate(rangeStart);
     const selectedRangeEnd = parseISODate(rangeEnd);
 
-
     return events.filter((event) => {
       const eventDate = parseISODate(event.date);
       if (!eventDate) return false;
 
       // Text search: title, description, tags
       const matchesSearch =
-      !term ||
-      String(event.title || "")
-        .toLowerCase()
-        .includes(term) ||
-      String(event.description || "")
-        .toLowerCase()
-        .includes(term) ||
-      (Array.isArray(event.tags) &&
-        event.tags.some((tag) =>
-          String(tag || "").toLowerCase().includes(term)
-        ));
+        !term ||
+        String(event.title || "")
+          .toLowerCase()
+          .includes(term) ||
+        String(event.description || "")
+          .toLowerCase()
+          .includes(term) ||
+        (Array.isArray(event.tags) &&
+          event.tags.some((tag) =>
+            String(tag || "")
+              .toLowerCase()
+              .includes(term),
+          ));
 
       // Region filter
       const matchesRegion = !selectedRegion || event.region === selectedRegion;
@@ -387,74 +387,76 @@ export default function App() {
           </div>
         </div>
 
-       {viewMode === "grid" ? (
-        <div className="events-grid" id="events-grid">
-          {filteredEvents && filteredEvents.length > 0 ?(
-            filteredEvents.map((event) => (
-              <EventCard key={event.id} event={event} viewMode="grid" />
-            ))
-          ) : (
-            <div className="empty-state" id="empty-state">
-              <div className="empty-state__icon">🔎</div>
-              <h2 className="empty-state__title">No events found</h2>
-              <button
-                onClick={resetFilters}
-                style={{
-                  marginTop: "10px",
-                  padding: "8px 16px",
-                  cursor: "pointer",
-                }}
-              >
-                Reset Filters
-              </button>
+        {viewMode === "grid" ? (
+          <div className="events-grid" id="events-grid">
+            {filteredEvents && filteredEvents.length > 0 ? (
+              filteredEvents.map((event) => (
+                <EventCard key={event.id} event={event} viewMode="grid" />
+              ))
+            ) : (
+              <div className="empty-state" id="empty-state">
+                <div className="empty-state__icon">🔎</div>
+                <h2 className="empty-state__title">No events found</h2>
+                <button
+                  onClick={resetFilters}
+                  style={{
+                    marginTop: "10px",
+                    padding: "8px 16px",
+                    cursor: "pointer",
+                  }}
+                >
+                  Reset Filters
+                </button>
 
-              <p className="empty-state__description">
-                Try adjusting your search terms or filters to find events near you.
-              </p>
-            </div>
-          )}
-        </div>
-      ) : viewMode === "list" ? (
-        <div className="events-list" id="events-list">
-          {filteredEvents && filteredEvents.length > 0 ? (
-            Object.entries(groupedEvents).map(([month, monthEvents]) => (
-              <div key={month} className="events-list__month-group">
-                <h3 className="events-list__month-heading">{month}</h3>
-                <div className="events-list__month-rows">
-                  {monthEvents.map((event) => (
-                    <EventCard
-                      key={event.id}
-                      event={event}
-                      viewMode="list"
-                    />
-                  ))}
-                </div>
+                <p className="empty-state__description">
+                  Try adjusting your search terms or filters to find events
+                  near you.
+                </p>
               </div>
-            ))
-          ) : (
-            <div className="empty-state" id="empty-state">
-              <div className="empty-state__icon">🔎</div>
-              <h2 className="empty-state__title">No events found</h2>
-              <button
-               onClick={resetFilters}
-                style={{
-                  marginTop: "10px",
-                  padding: "8px 16px",
-                  cursor: "pointer",
-                }}
-              >
-                Reset Filters
-              </button>
+            )}
+          </div>
+        ) : viewMode === "list" ? (
+          <div className="events-list" id="events-list">
+            {filteredEvents && filteredEvents.length > 0 ? (
+              Object.entries(groupedEvents).map(([month, monthEvents]) => (
+                <div key={month} className="events-list__month-group">
+                  <h3 className="events-list__month-heading">{month}</h3>
+                  <div className="events-list__month-rows">
+                    {monthEvents.map((event) => (
+                      <EventCard
+                        key={event.id}
+                        event={event}
+                        viewMode="list"
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="empty-state" id="empty-state">
+                <div className="empty-state__icon">🔎</div>
+                <h2 className="empty-state__title">No events found</h2>
+                <button
+                  onClick={resetFilters}
+                  style={{
+                    marginTop: "10px",
+                    padding: "8px 16px",
+                    cursor: "pointer",
+                  }}
+                >
+                  Reset Filters
+                </button>
 
-              <p className="empty-state__description">
-                Try adjusting your search terms or filters to find events near you.
-              </p>
-            </div>
-          )}
-        </div>
-      ) : (
-        <EventMap events={filteredEvents} />
-      )}
+                <p className="empty-state__description">
+                  Try adjusting your search terms or filters to find events
+                  near you.
+                </p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <EventMap events={filteredEvents} />
+        )}
       </main>
       <Footer onNavigate={setCurrentPage} />
       <BackToTop />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,6 +88,17 @@ export default function App() {
     return unique.sort();
   }, []);
 
+  const resetFilters = () => {
+    setSearchTerm("");
+    setSelectedRegion("");
+    setSelectedCategory("");
+    setDateFilterType("all");
+    setCustomDate("");
+    setRangeStart("");
+    setRangeEnd("");
+  };
+
+
   const filteredEvents = useMemo(() => {
     const term = searchTerm.toLowerCase().trim();
 
@@ -108,17 +119,24 @@ export default function App() {
     const selectedRangeStart = parseISODate(rangeStart);
     const selectedRangeEnd = parseISODate(rangeEnd);
 
+
     return events.filter((event) => {
       const eventDate = parseISODate(event.date);
       if (!eventDate) return false;
 
       // Text search: title, description, tags
       const matchesSearch =
-        !term ||
-        event.title.toLowerCase().includes(term) ||
-        event.description.toLowerCase().includes(term) ||
-        (event.tags &&
-          event.tags.some((tag) => tag.toLowerCase().includes(term)));
+      !term ||
+      String(event.title || "")
+        .toLowerCase()
+        .includes(term) ||
+      String(event.description || "")
+        .toLowerCase()
+        .includes(term) ||
+      (Array.isArray(event.tags) &&
+        event.tags.some((tag) =>
+          String(tag || "").toLowerCase().includes(term)
+        ));
 
       // Region filter
       const matchesRegion = !selectedRegion || event.region === selectedRegion;
@@ -369,54 +387,75 @@ export default function App() {
           </div>
         </div>
 
-        {viewMode === "grid" ? (
-          <div className="events-grid" id="events-grid">
-            {filteredEvents.length > 0 ? (
-              filteredEvents.map((event) => (
-                <EventCard key={event.id} event={event} viewMode="grid" />
-              ))
-            ) : (
-              <div className="empty-state" id="empty-state">
-                <div className="empty-state__icon">🔎</div>
-                <h2 className="empty-state__title">No events found</h2>
-                <p className="empty-state__description">
-                  Try adjusting your search terms or filters to find events
-                  near you.
-                </p>
-              </div>
-            )}
-          </div>
-        ) : viewMode === "list" ? (
-          <div className="events-list" id="events-list">
-            {filteredEvents.length > 0 ? (
-              Object.entries(groupedEvents).map(([month, monthEvents]) => (
-                <div key={month} className="events-list__month-group">
-                  <h3 className="events-list__month-heading">{month}</h3>
-                  <div className="events-list__month-rows">
-                    {monthEvents.map((event) => (
-                      <EventCard
-                        key={event.id}
-                        event={event}
-                        viewMode="list"
-                      />
-                    ))}
-                  </div>
+       {viewMode === "grid" ? (
+        <div className="events-grid" id="events-grid">
+          {filteredEvents && filteredEvents.length > 0 ?(
+            filteredEvents.map((event) => (
+              <EventCard key={event.id} event={event} viewMode="grid" />
+            ))
+          ) : (
+            <div className="empty-state" id="empty-state">
+              <div className="empty-state__icon">🔎</div>
+              <h2 className="empty-state__title">No events match your filters</h2>
+              <button
+                onClick={resetFilters}
+                style={{
+                  marginTop: "10px",
+                  padding: "8px 16px",
+                  cursor: "pointer",
+                }}
+              >
+                Reset Filters
+              </button>
+
+              <p className="empty-state__description">
+                Try adjusting your search terms or filters to find events near you.
+              </p>
+            </div>
+          )}
+        </div>
+      ) : viewMode === "list" ? (
+        <div className="events-list" id="events-list">
+          {filteredEvents && filteredEvents.length > 0 ? (
+            Object.entries(groupedEvents).map(([month, monthEvents]) => (
+              <div key={month} className="events-list__month-group">
+                <h3 className="events-list__month-heading">{month}</h3>
+                <div className="events-list__month-rows">
+                  {monthEvents.map((event) => (
+                    <EventCard
+                      key={event.id}
+                      event={event}
+                      viewMode="list"
+                    />
+                  ))}
                 </div>
-              ))
-            ) : (
-              <div className="empty-state" id="empty-state">
-                <div className="empty-state__icon">🔎</div>
-                <h2 className="empty-state__title">No events found</h2>
-                <p className="empty-state__description">
-                  Try adjusting your search terms or filters to find events
-                  near you.
-                </p>
               </div>
-            )}
-          </div>
-        ) : (
-          <EventMap events={filteredEvents} />
-        )}
+            ))
+          ) : (
+            <div className="empty-state" id="empty-state">
+              <div className="empty-state__icon">🔎</div>
+              <h2 className="empty-state__title">No events match your filters</h2>
+
+              <button
+               onClick={resetFilters}
+                style={{
+                  marginTop: "10px",
+                  padding: "8px 16px",
+                  cursor: "pointer",
+                }}
+              >
+                Reset Filters
+              </button>
+
+              <p className="empty-state__description">
+                Try adjusting your search terms or filters to find events near you.
+              </p>
+            </div>
+          )}
+        </div>
+      ) : (
+        <EventMap events={filteredEvents} />
+      )}
       </main>
       <Footer onNavigate={setCurrentPage} />
       <BackToTop />


### PR DESCRIPTION
## Summary
Adds a reset filters button to improve user experience when no events match the selected filters.

## Changes
- Added "Reset Filters" button in empty state (grid & list views)
- Implemented resetFilters function to clear all filters
- Fixed bug where reset was not clearing date filters
- Fixed crash issue caused by unsafe search filtering logic

## Problem
- Users had no quick way to reset filters
- Reset functionality was incomplete
- App crashed when typing multiple characters in search due to unsafe data handling

## Solution
- Added reset button for better UX
- Ensured all filters (including date filters) reset correctly
- Improved search logic using safe checks to prevent runtime errors

## Impact
- Improved usability
- Fixed critical crash bug
- Enhanced overall filtering experience