### PR TITLE
fix: set default date filter to upcoming to hide past events

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ export default function App() {
   const [currentPage, setCurrentPage] = useUrlState("page", "events");
   const [viewMode, setViewMode] = useUrlState("view", "grid");
 
-  const [dateFilterType, setDateFilterType] = useUrlState("dateType", "all");
+  const [dateFilterType, setDateFilterType] = useUrlState("dateType", "upcoming");
   const [customDate, setCustomDate] = useUrlState("customDate", "");
   const [rangeStart, setRangeStart] = useUrlState("rangeStart", "");
   const [rangeEnd, setRangeEnd] = useUrlState("rangeEnd", "");


### PR DESCRIPTION
 #32

Problem
The default `dateFilterType` state in `App.jsx` was set to `"all"`, 
causing past events to appear on first load.

Fix
Changed default value from `"all"` to `"upcoming"` so only 
Upcoming events are shown by default, as specified in the project plan.

Changes
- `src/App.jsx`: changed `useState("all")` to `useState("upcoming")`