### PR TITLE
fix(tests): mock window.scrollTo to suppress jsdom warnings

### DIFF
--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,2 @@
 import "@testing-library/jest-dom";
+window.scrollTo = vi.fn();


### PR DESCRIPTION
## Pull Request description

Adds a `window.scrollTo` mock in the test setup file to suppress
jsdom "Not implemented" warnings that appear on every test run.

jsdom does not implement `window.scrollTo`. Currently all 15 tests
print this warning in stderr, making test output noisy and harder
to scan for real failures. This change silences it without affecting
test behaviour.

## How to test these changes

- Run `npm run test`
- Confirm all 15 tests pass with zero `Not implemented: window.scrollTo`
  warnings in stderr

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

Before this fix :  stderr printed on every test run:

Error: Not implemented: window.scrollTo


After this fix:  clean output, all 15 tests pass silently.