### PR TITLE
fix: align learn more button to bottom of event card in grid view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -674,6 +674,8 @@ span.event-list-row__title {
   position: relative;
   overflow: hidden;
   cursor: default;
+  display: flex;
+  flex-direction: column;
 }
 
 .event-card::before {
@@ -868,6 +870,8 @@ span.event-list-row__title {
   background: rgba(124, 92, 252, 0.08);
   border: 1px solid rgba(124, 92, 252, 0.15);
   transition: all var(--transition-base);
+  margin-top: auto;
+  align-self: flex-start;
 }
 
 .event-card__link:hover {


### PR DESCRIPTION
Added display: flex; and flex-direction: column; to the .event-card class.

Added margin-top: auto; and align-self: flex-start; to the .event-card__link class.

BEFORE: 
<img width="1208" height="118" alt="image" src="https://github.com/user-attachments/assets/45940f6d-bcb3-4fcb-bc64-37040d9b525b" />

AFTER:
<img width="1133" height="104" alt="Screenshot 2026-04-01 at 6 59 05 PM" src="https://github.com/user-attachments/assets/05860be8-50a0-465b-b6cd-f7ded11f1cfd" />

