### PR TITLE
fix(search): hide date range inputs when 'All Dates' is selected

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -188,3 +188,4 @@ export default function SearchBar({
     </div>
   );
 }
+

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -114,7 +114,7 @@ export default function SearchBar({
             </div>
           )}
 
-          {dateFilterType !== "customDate" && (
+          {dateFilterType === "customRange" && (
             <div
               className="search__date-group"
               style={{
@@ -140,8 +140,6 @@ export default function SearchBar({
                 value={rangeStart}
                 max={rangeEnd || undefined}
                 onChange={(e) => {
-                  if (dateFilterType !== "customRange")
-                    onDateFilterTypeChange("customRange");
                   onRangeStartChange(e.target.value);
                 }}
                 aria-label="Range start date"
@@ -169,8 +167,6 @@ export default function SearchBar({
                 value={rangeEnd}
                 min={rangeStart || undefined}
                 onChange={(e) => {
-                  if (dateFilterType !== "customRange")
-                    onDateFilterTypeChange("customRange");
                   onRangeEndChange(e.target.value);
                 }}
                 aria-label="Range end date"
@@ -188,4 +184,3 @@ export default function SearchBar({
     </div>
   );
 }
-


### PR DESCRIPTION
## Pull Request description

Fix for issue #121 — Date filter "Start Date" and "End Date" 
inputs were visible even when "All Dates" was selected.

**Root cause:** Condition `dateFilterType !== "customDate"` was 
showing range inputs for ALL filter types except customDate.

**Fix:** Changed to `dateFilterType === "customRange"` so inputs 
only render when Custom Range is explicitly selected.

Fixes #121

## How to test these changes

- Run `npm run dev`
- Open the Event Board
- Select "All Dates" → confirm Start/End inputs are hidden ✅
- Select "Upcoming", "This Week", "This Month" → inputs hidden ✅
- Select "Custom Date" → only single date input shows ✅
- Select "Custom Range" → Start/End inputs appear ✅

## Pull Request checklists

This PR is a:

- [x] bug-fix

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

Before fix: Start/End date inputs visible on all filter modes.
After fix: Inputs only visible when "Custom Range" is selected.