### PR TITLE
test: add pytest coverage for generate_events_json validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,8 +94,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install PyYAML
-        run: pip install pyyaml
+      - name: Install Python dependencies
+        run: pip install pyyaml pytest
+
+      - name: Run generator unit tests
+        run: pytest tests/ -q
 
       - name: Backup committed events.json
         run: cp src/data/events.json src/data/events.json.committed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
         pass_filenames: true
         require_serial: yes
         files: "./"
+        exclude: ^tests/
         types:
           - python
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,8 @@ npm run dev
    npm run lint
    pytest tests/
    ```
-   (`pytest` needs the conda env; it covers `scripts/generate_events_json.py` validation helpers.)
+   (`pytest` needs the conda env; it covers `scripts/generate_events_json.py`
+   validation helpers.)
 5. Commit your changes using
    [conventional commits](https://www.conventionalcommits.org/)
 6. Push to the branch (`git push origin feat/amazing-feature`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ npm run dev
    ```bash
    npm run test
    npm run lint
+   pytest tests/
    ```
+   (`pytest` needs the conda env; it covers `scripts/generate_events_json.py` validation helpers.)
 5. Commit your changes using
    [conventional commits](https://www.conventionalcommits.org/)
 6. Push to the branch (`git push origin feat/amazing-feature`)

--- a/conda.yaml
+++ b/conda.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pyyaml
   - pip
   - pip:
+      - pytest
       - pre-commit
       - ruff
       - mypy

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+// jsdom doesn't implement scrollTo; App uses it in a useEffect.
+window.scrollTo = vi.fn();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test-only: let `import generate_events_json` resolve from scripts/."""
+
+import sys
+from pathlib import Path
+
+_scripts = Path(__file__).resolve().parent.parent / "scripts"
+if str(_scripts) not in sys.path:
+    sys.path.insert(0, str(_scripts))

--- a/tests/test_generate_events_json.py
+++ b/tests/test_generate_events_json.py
@@ -1,0 +1,55 @@
+"""Unit tests for event dict validation (no YAML files, no network)."""
+
+from __future__ import annotations
+
+import generate_events_json as gen
+
+
+def _minimal_event(**overrides: object) -> dict:
+    ev: dict = {
+        "id": "99",
+        "title": "Test event",
+        "description": "Desc",
+        "date": "2026-08-01",
+        "time": "15:00",
+        "location": "Somewhere",
+        "region": "North",
+        "category": "Technology",
+    }
+    ev.update(overrides)
+    return ev
+
+
+def test_validate_ok_for_sensible_event() -> None:
+    err = gen.validate_event(_minimal_event(), 1)
+    assert err == []
+
+
+def test_missing_required_field() -> None:
+    ev = _minimal_event()
+    del ev["title"]
+    err = gen.validate_event(ev, 1)
+    assert len(err) == 1
+    assert "title" in err[0].lower() or "Missing" in err[0]
+
+
+def test_invalid_date_string() -> None:
+    err = gen.validate_event(_minimal_event(date="not-a-date"), 1)
+    assert any("date" in e.lower() for e in err)
+
+
+def test_invalid_time_string() -> None:
+    err = gen.validate_event(_minimal_event(time="25:99"), 1)
+    assert any("time" in e.lower() for e in err)
+
+
+def test_datetime_objects_get_normalized_like_yaml() -> None:
+    from datetime import datetime
+
+    ev = _minimal_event(
+        date=datetime(2026, 1, 15),
+        time=datetime(1900, 1, 1, 9, 30),
+    )
+    assert gen.validate_event(ev, 1) == []
+    assert ev["date"] == "2026-01-15"
+    assert ev["time"] == "09:30"


### PR DESCRIPTION
## What
- Adds `tests/` with a few unit tests that call `validate_event` directly (dicts only — no YAML file, no network).
- Wires `pytest tests/` into the existing `validate-events` CI job (after `pip install pytest`).
- Adds `pytest` to `conda.yaml` and mentions `pytest tests/` in `CONTRIBUTING.md`.

## Why
The generator is easy to break when `validate_event` changes; JS already has Vitest — this gives the Python side a small regression net without slowing the rest of CI much.

## Note
`douki` is set to skip `tests/` in `.pre-commit-config.yaml` so we don’t need script-style docstrings on every test helper. Happy to change if maintainers prefer full douki on tests.

## Related
Closes  #164 

---

**How to run locally:** activate the conda env, then `pytest tests/` from repo root.