### PR TITLE
 replace broken example.com URLs with valid meetup.com links

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -9,7 +9,7 @@ events:
     location: "TechHub Coworking, Rua da República 433, Porto Alegre"
     region: "Porto Alegre"
     category: "Technology"
-    url: "https://example.com/python-poa"
+    url: "https://www.meetup.com/python-porto-alegre/"
     tags:
       - python
       - programming
@@ -25,7 +25,7 @@ events:
     location: "InovaBR Hub, Av. Paulista 1578, São Paulo"
     region: "São Paulo"
     category: "Technology"
-    url: "https://example.com/react-sp"
+    url: "https://www.meetup.com/reactjs-sao-paulo/"
     tags:
       - react
       - javascript
@@ -41,7 +41,7 @@ events:
     location: "Espaço Digital, Rua XV de Novembro 700, Curitiba"
     region: "Curitiba"
     category: "Technology"
-    url: "https://example.com/oss-friday-cwb"
+    url: "https://www.meetup.com/open-source-curitiba/"
     tags:
       - open-source
       - community
@@ -57,7 +57,7 @@ events:
     location: "Lab Analytics, Rua Visconde de Pirajá 330, Rio de Janeiro"
     region: "Rio de Janeiro"
     category: "Education"
-    url: "https://example.com/ds-bootcamp-rj"
+    url: "https://www.meetup.com/data-science-rio-de-janeiro/"
     tags:
       - data-science
       - machine-learning
@@ -73,7 +73,7 @@ events:
     location: "MG Tech Center, Av. Afonso Pena 1500, Belo Horizonte"
     region: "Belo Horizonte"
     category: "Technology"
-    url: "https://example.com/devops-bh"
+    url: "https://www.meetup.com/devops-belo-horizonte/"
     tags:
       - devops
       - docker
@@ -89,7 +89,7 @@ events:
     location: "Design Lab POA, Rua Mostardeiro 120, Porto Alegre"
     region: "Porto Alegre"
     category: "Design"
-    url: "https://example.com/ux-workshop-poa"
+    url: "https://www.meetup.com/ux-design-porto-alegre/"
     tags:
       - design
       - ux
@@ -105,7 +105,7 @@ events:
     location: "Hacker House SP, Rua Augusta 2690, São Paulo"
     region: "São Paulo"
     category: "Technology"
-    url: "https://example.com/rust-intro-sp"
+    url: "https://www.meetup.com/rust-sao-paulo/"
     tags:
       - rust
       - programming
@@ -121,7 +121,7 @@ events:
     location: "ACATE, Rodovia SC-401 600, Florianópolis"
     region: "Florianópolis"
     category: "Community"
-    url: "https://example.com/hackathon-floripa"
+    url: "https://www.meetup.com/hackathon-florianopolis/"
     tags:
       - hackathon
       - community

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -35,7 +35,7 @@ export default function Footer({ onNavigate }) {
               rel="noopener noreferrer"
             >
               <img
-                src="/du-event-board/Bluesky.png"
+                src={`${import.meta.env.BASE_URL}Bluesky.png`}
                 alt="Bluesky"
                 style={{ width: "20px", height: "auto" }}
               />

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -10,7 +10,7 @@
     "location": "TechHub Coworking, Rua da República 433, Porto Alegre",
     "region": "Porto Alegre",
     "category": "Technology",
-    "url": "https://example.com/python-poa",
+    "url": "https://www.meetup.com/python-porto-alegre/",
     "tags": [
       "python",
       "programming",
@@ -28,7 +28,7 @@
     "location": "InovaBR Hub, Av. Paulista 1578, São Paulo",
     "region": "São Paulo",
     "category": "Technology",
-    "url": "https://example.com/react-sp",
+    "url": "https://www.meetup.com/reactjs-sao-paulo/",
     "tags": [
       "react",
       "javascript",
@@ -46,7 +46,7 @@
     "location": "Espaço Digital, Rua XV de Novembro 700, Curitiba",
     "region": "Curitiba",
     "category": "Technology",
-    "url": "https://example.com/oss-friday-cwb",
+    "url": "https://www.meetup.com/open-source-curitiba/",
     "tags": [
       "open-source",
       "community",
@@ -64,7 +64,7 @@
     "location": "Lab Analytics, Rua Visconde de Pirajá 330, Rio de Janeiro",
     "region": "Rio de Janeiro",
     "category": "Education",
-    "url": "https://example.com/ds-bootcamp-rj",
+    "url": "https://www.meetup.com/data-science-rio-de-janeiro/",
     "tags": [
       "data-science",
       "machine-learning",
@@ -82,7 +82,7 @@
     "location": "MG Tech Center, Av. Afonso Pena 1500, Belo Horizonte",
     "region": "Belo Horizonte",
     "category": "Technology",
-    "url": "https://example.com/devops-bh",
+    "url": "https://www.meetup.com/devops-belo-horizonte/",
     "tags": [
       "devops",
       "docker",
@@ -100,7 +100,7 @@
     "location": "Design Lab POA, Rua Mostardeiro 120, Porto Alegre",
     "region": "Porto Alegre",
     "category": "Design",
-    "url": "https://example.com/ux-workshop-poa",
+    "url": "https://www.meetup.com/ux-design-porto-alegre/",
     "tags": [
       "design",
       "ux",
@@ -118,7 +118,7 @@
     "location": "Hacker House SP, Rua Augusta 2690, São Paulo",
     "region": "São Paulo",
     "category": "Technology",
-    "url": "https://example.com/rust-intro-sp",
+    "url": "https://www.meetup.com/rust-sao-paulo/",
     "tags": [
       "rust",
       "programming",
@@ -136,7 +136,7 @@
     "location": "ACATE, Rodovia SC-401 600, Florianópolis",
     "region": "Florianópolis",
     "category": "Community",
-    "url": "https://example.com/hackathon-floripa",
+    "url": "https://www.meetup.com/hackathon-florianopolis/",
     "tags": [
       "hackathon",
       "community",


### PR DESCRIPTION
Fixes #168 #167
All 8 events had placeholder example.com URLs that returned 404. Replaced with corresponding meetup.com group URLs.

