### PR TITLE
fix: support custom domain deployment for events.dataumbrella.org

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,13 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 const isNetlify = process.env.NETLIFY === "true";
+const isCustomDomain =
+  process.env.GITHUB_PAGES_CUSTOM_DOMAIN === "true" ||
+  process.env.CUSTOM_DOMAIN === "true";
 
 export default defineConfig({
   plugins: [react()],
-  base: isNetlify ? "/" : "/du-event-board/",
+  base: isNetlify || isCustomDomain ? "/" : "/du-event-board/",
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
This PR updates the Vite `base` configuration to correctly support deployment to the custom domain `events.dataumbrella.org`.


Updated `vite.config.js` so that the `base` path is set to `/` when deploying to:
- Netlify
- GitHub Pages with a custom domain
