### PR TITLE
Fix vite base root

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-const isNetlify = process.env.NETLIFY === "true";
-const isCustomDomain =
-  process.env.GITHUB_PAGES_CUSTOM_DOMAIN === "true" ||
-  process.env.CUSTOM_DOMAIN === "true";
-
 export default defineConfig({
   plugins: [react()],
-  base: isNetlify || isCustomDomain ? "/" : "/du-event-board/",
+  base: "/",
   test: {
     environment: "jsdom",
     globals: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,13 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 const isNetlify = process.env.NETLIFY === "true";
+const isCustomDomain =
+  process.env.GITHUB_PAGES_CUSTOM_DOMAIN === "true" ||
+  process.env.CUSTOM_DOMAIN === "true";
 
 export default defineConfig({
   plugins: [react()],
-  base: isNetlify ? "/" : "/du-event-board/",
+  base: isNetlify || isCustomDomain ? "/" : "/du-event-board/",
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
Set `base: "/"` unconditionally in `vite.config.js`.

The previous configuration relied on environment variables (`NETLIFY`, `CUSTOM_DOMAIN`) and was causing assets to be generated under `/du-event-board/` and resulting in a blank page on `events.dataumbrella.org`.

Using `base: "/"` works for both Netlify and the custom domain, so the conditional logic is no longer needed.