### PR TITLE
Add dynamic SPA document titles and GA page view tracking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -141,9 +141,8 @@ export default function App() {
 
     // 2. Explicitly tell Google Analytics that the page has changed
     if (typeof window !== "undefined" && typeof window.gtag === "function") {
-      const pagePath = window.location.pathname + window.location.search;
       window.gtag("event", "page_view", {
-        page_path: pagePath,
+        page_location: window.location.href,
         page_title: document.title,
       });
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,7 +122,32 @@ export default function App() {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [currentPage]);
+
+    // 1. Update Document Title dynamically for any page added now or in the future
+    let newTitle = "DU Event Board - Discover Events Near You";
+
+    if (currentPage === "event-details" && selectedEvent) {
+      newTitle = `${selectedEvent.title} | DU Event Board`;
+    } else if (currentPage && currentPage !== "events") {
+      // Auto-formats "about-us" to "About Us" or "sponsors" to "Sponsors"
+      const formattedPage = currentPage
+        .split("-")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      newTitle = `${formattedPage} | DU Event Board`;
+    }
+
+    document.title = newTitle;
+
+    // 2. Explicitly tell Google Analytics that the page has changed
+    if (typeof window !== "undefined" && typeof window.gtag === "function") {
+      const pagePath = window.location.pathname + window.location.search;
+      window.gtag("event", "page_view", {
+        page_path: pagePath,
+        page_title: document.title,
+      });
+    }
+  }, [currentPage, selectedEvent]);
 
   const [theme, setTheme] = useState(() => {
     // Check if we are in a browser and if localStorage.getItem actually exists

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,9 @@ export default defineConfig({
       analytics: {
         provider: "ga",
         id: "G-E5SMJ9E985",
+        config: {
+          send_page_view: false,
+        },
       },
     }),
   ],


### PR DESCRIPTION
closes #178 related #183 
**SPA (Single Page Application) Support**: In a SPA, navigating between pages doesn't trigger a full browser reload, meaning the document title usually stays the same. I implemented a dynamic document.title generator that hooks into the router's state. Now, whenever a user opens a specific event or page, the browser tab instantly updates. This ensures browser history, tabs, bookmarks, and screen readers all capture the correct context.

https://github.com/user-attachments/assets/132ed09c-a21b-45d4-9e88-bdc6147e952a

**Google Analytics (GA)**: Because SPAs do not reload the page, traditional Google Analytics tracking misses subsequent page views. To fix this, I integrated an explicit gtag trigger that fires precisely when the URL state changes. This explicitly forces Google Analytics to record a new "Page View", passing along the updated URL path and the dynamic title we generated above, ensuring all event traffic is flawlessly tracked without needing a hard refresh.

The implementation in PR #183 sent hardcoded titles to GA but forgot to update the actual document.title in the browser tab, defeating the usability benefits of SPA support. Furthermore, it dropped the eventId from the tracked URL path (preventing GA from tracking which specific events were viewed) and used a rigid ternary operator that failed to fetch actual event names or scale automatically to new pages.

https://github.com/user-attachments/assets/877aaf45-1097-49d0-a53a-86f758b311e2
