### PR TITLE
add frontend and backend unit tests with CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,9 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: write
+      contents: read
 
     concurrency:
       group: ci-lint-test-${{ github.ref }}
@@ -72,11 +75,39 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Run tests
-        run: npm run test
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Report Coverage
+        uses: davelosert/vitest-coverage-report-action@v2
+        if: always()
 
       - name: Build
         run: npm run build
+
+  test-backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    concurrency:
+      group: ci-test-backend-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install pyyaml requests pytest pytest-cov pytest-mock
+
+      - name: Run Python tests with coverage
+        run: python -m pytest tests/ --cov=scripts --cov-report=term-missing
 
   validate-events:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         language: system
         pass_filenames: true
         require_serial: yes
-        files: "./"
+        files: "scripts/"
         types:
           - python
 
@@ -80,3 +80,11 @@ repos:
         types_or:
           - javascript
           - jsx
+
+      - id: pytest
+        name: pytest
+        entry: python3 -m pytest tests/
+        language: system
+        pass_filenames: false
+        types:
+          - python

--- a/conda.yaml
+++ b/conda.yaml
@@ -16,3 +16,5 @@ dependencies:
       - types-PyYAML
       - douki
       - requests
+      - pytest
+      - pytest-mock

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "^2.1.8",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -42,6 +43,20 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -355,6 +370,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1122,6 +1144,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1170,6 +1220,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -1732,15 +1793,48 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.8.tgz",
+      "integrity": "sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.8",
+        "vitest": "2.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
         "chai": "^5.1.2",
         "tinyrainbow": "^1.2.0"
       },
@@ -1762,13 +1856,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
+        "@vitest/utils": "2.1.8",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -1776,13 +1870,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
+        "@vitest/pretty-format": "2.1.8",
         "magic-string": "^0.30.12",
         "pathe": "^1.1.2"
       },
@@ -1790,10 +1884,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1804,14 +1911,27 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
+        "@vitest/pretty-format": "2.1.8",
         "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -1874,7 +1994,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2626,6 +2745,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
@@ -3295,6 +3421,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -3481,6 +3624,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3492,6 +3657,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3643,6 +3834,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3908,6 +4106,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -4150,6 +4358,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4166,6 +4428,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-tokens": {
@@ -4423,6 +4701,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4477,6 +4796,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/motion-dom": {
@@ -4736,6 +5065,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4788,6 +5124,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -5384,6 +5744,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5420,6 +5793,60 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -5535,6 +5962,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -5593,6 +6063,60 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5934,9 +6458,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6456,19 +6980,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
         "chai": "^5.1.2",
         "debug": "^4.3.7",
         "expect-type": "^1.1.0",
@@ -6480,7 +7004,7 @@
         "tinypool": "^1.0.1",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "vite-node": "2.1.8",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -6495,8 +7019,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -6913,13 +7437,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "2.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.12"
       },
@@ -7229,6 +7753,91 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "generate": "python3 scripts/generate_events_json.py || python scripts/generate_events_json.py",
     "prebuild": "python3 scripts/generate_events_json.py || python scripts/generate_events_json.py"
   },
@@ -29,6 +30,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^2.1.8",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/src/components/__tests__/EventCard.test.jsx
+++ b/src/components/__tests__/EventCard.test.jsx
@@ -1,0 +1,165 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import EventCard from "../EventCard";
+
+// Mock getEventStatus since it relies on current dates which might change
+vi.mock("../../utils/eventHelpers", () => ({
+  getEventStatus: vi.fn(() => "upcoming"),
+}));
+
+const mockEvent = {
+  id: "123",
+  title: "Test Meetup",
+  description: "A great meetup",
+  category: "Tech",
+  date: "2025-10-15",
+  start_time: "14:00",
+  end_time: "16:00",
+  location: "Online",
+  paid_or_free: "free",
+  tags: ["react", "testing"],
+};
+
+describe("EventCard Component", () => {
+  it("renders correctly in grid mode", () => {
+    render(
+      <EventCard event={mockEvent} viewMode="grid" onSelectEvent={() => {}} />,
+    );
+    expect(screen.getByText("Test Meetup")).toBeInTheDocument();
+    expect(screen.getByText("A great meetup")).toBeInTheDocument();
+    expect(screen.getByText("Tech")).toBeInTheDocument();
+    expect(screen.getByText("Online")).toBeInTheDocument();
+    expect(screen.getByText("Free")).toBeInTheDocument();
+    expect(screen.getByText("#react")).toBeInTheDocument();
+    expect(screen.getByText("#testing")).toBeInTheDocument();
+  });
+
+  it("renders correctly in list mode", () => {
+    render(
+      <EventCard event={mockEvent} viewMode="list" onSelectEvent={() => {}} />,
+    );
+    expect(screen.getByText("Test Meetup")).toBeInTheDocument();
+    expect(screen.getByText("Tech")).toBeInTheDocument();
+    expect(screen.queryByText("A great meetup")).not.toBeInTheDocument(); // Description not in list
+  });
+
+  it("renders correctly with an end_date but no time (like PyOhio conference)", () => {
+    const multiDayEvent = {
+      ...mockEvent,
+      end_date: "2025-10-16",
+    };
+    delete multiDayEvent.start_time;
+    delete multiDayEvent.end_time;
+    delete multiDayEvent.time;
+
+    render(
+      <EventCard
+        event={multiDayEvent}
+        viewMode="grid"
+        onSelectEvent={() => {}}
+      />,
+    );
+    // Should display just the dates without times
+    expect(
+      screen.getByText("October 15, 2025 – October 16, 2025"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSelectEvent when clicked (grid view)", () => {
+    const handleSelect = vi.fn();
+    render(
+      <EventCard
+        event={mockEvent}
+        viewMode="grid"
+        onSelectEvent={handleSelect}
+      />,
+    );
+
+    // The article is clickable
+    const card = screen.getByRole("article");
+    fireEvent.click(card);
+    expect(handleSelect).toHaveBeenCalledWith("123");
+  });
+
+  it("calls onSelectEvent when title link is clicked (list view)", () => {
+    const handleSelect = vi.fn();
+    render(
+      <EventCard
+        event={mockEvent}
+        viewMode="list"
+        onSelectEvent={handleSelect}
+      />,
+    );
+
+    const titleLink = screen.getByText("Test Meetup");
+    fireEvent.click(titleLink);
+    expect(handleSelect).toHaveBeenCalledWith("123");
+  });
+
+  it("renders gracefully when tags and paid_or_free are missing", () => {
+    const sparseEvent = {
+      id: "456",
+      title: "Sparse Meetup",
+      date: "2025-11-01",
+      category: "Tech",
+    };
+    render(
+      <EventCard
+        event={sparseEvent}
+        viewMode="grid"
+        onSelectEvent={() => {}}
+      />,
+    );
+    expect(screen.getByText("Sparse Meetup")).toBeInTheDocument();
+    // Free icon/text should not be displayed
+    expect(screen.queryByText("Free")).not.toBeInTheDocument();
+    expect(screen.queryByText("Paid")).not.toBeInTheDocument();
+  });
+
+  it("renders correctly with only a generic time field instead of start/end times", () => {
+    const timeEvent = {
+      ...mockEvent,
+      time: "19:00",
+    };
+    delete timeEvent.start_time;
+    delete timeEvent.end_time;
+    render(
+      <EventCard event={timeEvent} viewMode="grid" onSelectEvent={() => {}} />,
+    );
+    // Format should fallback to date • time
+    expect(screen.getByText("October 15, 2025 • 19:00")).toBeInTheDocument();
+  });
+
+  it("renders gracefully when date is empty or malformed", () => {
+    const badDateEvent = {
+      ...mockEvent,
+      date: "",
+      time: "",
+    };
+    render(
+      <EventCard
+        event={badDateEvent}
+        viewMode="grid"
+        onSelectEvent={() => {}}
+      />,
+    );
+    expect(screen.getByText("Test Meetup")).toBeInTheDocument();
+  });
+
+  it("stops propagation when clicking the title link in grid view", () => {
+    const handleSelect = vi.fn();
+    render(
+      <EventCard
+        event={mockEvent}
+        viewMode="grid"
+        onSelectEvent={handleSelect}
+      />,
+    );
+
+    const titleLink = screen.getByText("Test Meetup");
+    fireEvent.click(titleLink);
+    // Should be called only once
+    expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith("123");
+  });
+});

--- a/src/components/__tests__/EventDetails.test.jsx
+++ b/src/components/__tests__/EventDetails.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import EventDetails from "../EventDetails";
+
+const mockEvent = {
+  id: "1",
+  title: "Global Summit",
+  description: "A very large summit.",
+  date: "2025-12-01",
+  end_date: "2025-12-03",
+  location: "Convention Center",
+  city: "New York",
+  category: "Conference",
+  tags: ["tech", "networking"],
+  paid_or_free: "paid",
+  url: "https://example.com",
+};
+
+describe("EventDetails Component", () => {
+  it("returns null if no event is provided", () => {
+    const { container } = render(
+      <EventDetails event={null} onBack={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders event details correctly", () => {
+    render(<EventDetails event={mockEvent} onBack={() => {}} />);
+
+    // Check main elements
+    expect(screen.getByText("Global Summit")).toBeInTheDocument();
+    expect(screen.getByText("A very large summit.")).toBeInTheDocument();
+    expect(screen.getByText("Conference")).toBeInTheDocument(); // Category badge
+    expect(screen.getByText("Paid")).toBeInTheDocument(); // Cost badge
+    expect(screen.getByText("#tech")).toBeInTheDocument();
+    expect(screen.getByText("#networking")).toBeInTheDocument();
+
+    // Check sidebar info
+    expect(
+      screen.getByText("December 1, 2025 – December 3, 2025"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Convention Center")).toBeInTheDocument();
+    expect(screen.getByText("New York")).toBeInTheDocument();
+  });
+
+  it("calls onBack when back button is clicked", () => {
+    const handleBack = vi.fn();
+    render(<EventDetails event={mockEvent} onBack={handleBack} />);
+
+    const backBtn = screen.getByRole("button", { name: /Back to Events/i });
+    fireEvent.click(backBtn);
+
+    expect(handleBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the map if coords are missing", () => {
+    render(<EventDetails event={mockEvent} onBack={() => {}} />);
+    expect(screen.queryByText("Event Map Location")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/EventMap.test.jsx
+++ b/src/components/__tests__/EventMap.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import EventMap from "../EventMap";
+
+describe("EventMap Component", () => {
+  it("renders the empty state when no events have coordinates", () => {
+    const eventsWithoutCoords = [
+      { id: "1", title: "Online Event", location: "Online" },
+    ];
+    render(
+      <EventMap
+        events={eventsWithoutCoords}
+        theme="light"
+        onSelectEvent={() => {}}
+      />,
+    );
+    expect(screen.getByText("No locations found")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Header.test.jsx
+++ b/src/components/__tests__/Header.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import Header from "../Header";
+
+describe("Header Component", () => {
+  it("renders the brand name and tagline", () => {
+    render(<Header theme="light" onToggleTheme={() => {}} />);
+    expect(screen.getByText("DU Event Board")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Discover tech events, meetups/),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onToggleTheme when the theme button is clicked", () => {
+    const handleToggle = vi.fn();
+    render(<Header theme="light" onToggleTheme={handleToggle} />);
+
+    const toggleButton = screen.getByLabelText("Toggle Theme");
+    fireEvent.click(toggleButton);
+    expect(handleToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays correct icon based on theme", () => {
+    const { rerender } = render(
+      <Header theme="light" onToggleTheme={() => {}} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /Toggle Theme/i }),
+    ).toHaveTextContent("🌙");
+
+    rerender(<Header theme="dark" onToggleTheme={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: /Toggle Theme/i }),
+    ).toHaveTextContent("☀️");
+  });
+
+  it("calls onNavigate when events button is clicked", () => {
+    const handleNavigate = vi.fn();
+    render(
+      <Header
+        theme="light"
+        onToggleTheme={() => {}}
+        onNavigate={handleNavigate}
+      />,
+    );
+
+    const eventsButton = screen.getByText("Events");
+    fireEvent.click(eventsButton);
+    expect(handleNavigate).toHaveBeenCalledWith("events");
+  });
+
+  it("falls back to window.location.href when onNavigate is not provided", () => {
+    // Save original location
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { href: "http://localhost" };
+
+    render(<Header theme="light" onToggleTheme={() => {}} />);
+
+    const eventsButton = screen.getByText("Events");
+    fireEvent.click(eventsButton);
+
+    expect(window.location.href).toBe("/");
+
+    // Restore location
+    window.location = originalLocation;
+  });
+});

--- a/src/components/__tests__/SearchBar.test.jsx
+++ b/src/components/__tests__/SearchBar.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import SearchBar from "../SearchBar";
+
+describe("SearchBar Component", () => {
+  it("renders search input and calls onSearchChange", () => {
+    const handleSearchChange = vi.fn();
+    render(
+      <SearchBar
+        searchTerm=""
+        onSearchChange={handleSearchChange}
+        dateFilterType="all"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/Search events/i);
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "Python" } });
+    expect(handleSearchChange).toHaveBeenCalledWith("Python");
+  });
+
+  it("enables the Clear Filters button when there are active filters", () => {
+    const handleClear = vi.fn();
+    // Pass a non-empty search term to make filters active
+    render(
+      <SearchBar
+        searchTerm="React"
+        onSearchChange={handleClear}
+        dateFilterType="all"
+        onDateFilterTypeChange={() => {}}
+        onRegionChange={() => {}}
+        onCategoryChange={() => {}}
+        onCustomDateChange={() => {}}
+        onRangeStartChange={() => {}}
+        onRangeEndChange={() => {}}
+      />,
+    );
+
+    const clearBtn = screen.getByTitle("Clear all filters");
+    expect(clearBtn).not.toBeDisabled();
+
+    fireEvent.click(clearBtn);
+    expect(handleClear).toHaveBeenCalledWith("");
+  });
+});

--- a/src/components/__tests__/SearchableSelect.test.jsx
+++ b/src/components/__tests__/SearchableSelect.test.jsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import SearchableSelect from "../SearchableSelect";
+
+describe("SearchableSelect Component", () => {
+  const options = ["React", "Python", "Vue"];
+
+  it("renders input with placeholder", () => {
+    render(
+      <SearchableSelect
+        options={options}
+        value=""
+        onChange={() => {}}
+        placeholder="Select tech"
+        id="tech-select"
+      />,
+    );
+    expect(screen.getByPlaceholderText("Select tech")).toBeInTheDocument();
+  });
+
+  it("opens dropdown and filters options when typing", () => {
+    render(
+      <SearchableSelect
+        options={options}
+        value=""
+        onChange={() => {}}
+        placeholder="Select tech"
+        id="tech-select"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Select tech");
+    fireEvent.change(input, { target: { value: "re" } }); // Should match 'React'
+
+    expect(screen.getByText("React")).toBeInTheDocument();
+    expect(screen.queryByText("Python")).not.toBeInTheDocument();
+  });
+
+  it("calls onChange when an option is clicked", () => {
+    const handleChange = vi.fn();
+    render(
+      <SearchableSelect
+        options={options}
+        value=""
+        onChange={handleChange}
+        placeholder="Select tech"
+        id="tech-select"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Select tech");
+    fireEvent.click(input); // Open dropdown
+
+    const option = screen.getByText("Python");
+    fireEvent.click(option);
+
+    expect(handleChange).toHaveBeenCalledWith("Python");
+  });
+
+  it("clears selection when clear button is clicked", () => {
+    const handleChange = vi.fn();
+    render(
+      <SearchableSelect
+        options={options}
+        value="Python"
+        onChange={handleChange}
+        placeholder="Select tech"
+        id="tech-select"
+        clearable={true}
+      />,
+    );
+
+    const clearBtn = screen.getByTitle("Clear selection");
+    fireEvent.click(clearBtn);
+
+    expect(handleChange).toHaveBeenCalledWith("");
+  });
+});

--- a/src/utils/__tests__/eventHelpers.test.js
+++ b/src/utils/__tests__/eventHelpers.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getEventStatus } from "../eventHelpers";
+
+describe("eventHelpers - getEventStatus", () => {
+  beforeEach(() => {
+    // Mock the system date to a fixed date: 2025-10-15
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-10-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "none" if no date is provided', () => {
+    expect(getEventStatus(null)).toBe("none");
+    expect(getEventStatus("")).toBe("none");
+  });
+
+  it('returns "ended" for events in the past', () => {
+    expect(getEventStatus("2025-10-10")).toBe("ended");
+  });
+
+  it('returns "live" for events happening today', () => {
+    expect(getEventStatus("2025-10-15")).toBe("live");
+  });
+
+  it('returns "upcoming" for events within the next 3 days', () => {
+    expect(getEventStatus("2025-10-16")).toBe("upcoming"); // 1 day out
+    expect(getEventStatus("2025-10-18")).toBe("upcoming"); // 3 days out
+  });
+
+  it('returns "none" for events more than 3 days in the future', () => {
+    expect(getEventStatus("2025-10-19")).toBe("none"); // 4 days out
+    expect(getEventStatus("2026-01-01")).toBe("none");
+  });
+});

--- a/tests/test_add_event.py
+++ b/tests/test_add_event.py
@@ -1,0 +1,378 @@
+import os
+import json
+import pytest
+import subprocess
+from unittest.mock import patch, mock_open, MagicMock
+from scripts.add_event import (
+    parse_issue_body,
+    geocode_location_forced,
+    format_event_yaml,
+    main,
+)
+
+SAMPLE_ISSUE_BODY = """
+### Event Name
+Test Event
+
+### Start Date
+2026-10-10
+
+### Event Description (200 char max)
+_No response_
+"""
+
+def test_parse_issue_body():
+    parsed = parse_issue_body(SAMPLE_ISSUE_BODY)
+    assert parsed.get("Event Name") == "Test Event"
+    assert parsed.get("Start Date") == "2026-10-10"
+    assert parsed.get("Event Description (200 char max)") == ""
+
+def test_geocode_location_forced_online():
+    cache = {}
+    assert geocode_location_forced("Online", cache) is None
+    assert geocode_location_forced("", cache) is None
+
+def test_geocode_location_forced_cached():
+    cache = {"New York": [40.7, -74.0]}
+    assert geocode_location_forced("New York", cache) == (40.7, -74.0)
+
+@patch("urllib.request.urlopen")
+def test_geocode_location_forced_network_success(mock_urlopen):
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps([{"lat": "40.7", "lon": "-74.0"}]).encode()
+    mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+    cache = {}
+    coords = geocode_location_forced("New York", cache)
+
+    assert coords == (40.7, -74.0)
+    assert cache["New York"] == [40.7, -74.0]
+
+@patch("urllib.request.urlopen")
+def test_geocode_location_forced_network_exception(mock_urlopen):
+    mock_urlopen.side_effect = Exception("Network Error")
+    cache = {}
+    coords = geocode_location_forced("New York", cache)
+    assert coords is None
+
+def test_format_event_yaml():
+    event = {
+        "id": "12345",
+        "title": "Test Event",
+        "lat": 40.7,
+        "lng": -74.0,
+        "tags": ["Python", "Data"],
+        "paid_or_free": "Free",
+        "time": "14:00"
+    }
+    yaml_str = format_event_yaml(event)
+    assert '  - id: "12345"' in yaml_str
+    assert '    lat: 40.7' in yaml_str
+    assert '    lng: -74.0' in yaml_str
+    assert '    title: "Test Event"' in yaml_str
+    assert '    tags:\n      - Python\n      - Data' in yaml_str
+    assert '    paid_or_free: "Free"' in yaml_str
+    assert '    time: "14:00"' in yaml_str
+
+@patch("scripts.add_event.sys.exit")
+def test_main_missing_issue_body(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    monkeypatch.delenv("ISSUE_BODY", raising=False)
+    with pytest.raises(SystemExit):
+        main()
+    mock_exit.assert_called_once_with(1)
+
+@patch("scripts.add_event.sys.exit")
+def test_main_validation_fails(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    monkeypatch.setenv("ISSUE_BODY", "### Event Name\nTest Event")
+
+    with patch("builtins.open", mock_open()) as mock_file:
+        with pytest.raises(SystemExit):
+            main()
+        mock_exit.assert_called_once_with(1)
+        mock_file.assert_called_with("error_message.md", "w")
+
+@patch("scripts.add_event.sys.exit")
+@patch("scripts.add_event.geocode_location_forced")
+def test_main_success(mock_geocode, mock_exit, monkeypatch):
+    valid_body = """
+### Event Name
+Valid Event
+### Start Date
+2026-10-10
+### Tags
+Python, Open Source
+### Event Description (200 char max)
+A valid event
+### Event URL
+https://example.com
+### Location
+New York
+### Region (Continent)
+North America
+### Language
+English
+### Featured
+Yes
+### Start Time
+14:00
+### End Time
+16:00
+    """
+    monkeypatch.setenv("ISSUE_BODY", valid_body)
+    monkeypatch.setenv("GITHUB_OUTPUT", "github_out.txt")
+
+    mock_geocode.return_value = (40.7, -74.0)
+
+    def mock_file_open(filename, mode="r", *args, **kwargs):
+        if "events.yaml" in str(filename):
+            if "a" in mode:
+                return mock_open()()
+            else:
+                return mock_open(read_data="events: []\n")()
+        elif ".geocode_cache.json" in str(filename):
+            if "w" in mode:
+                return mock_open()()
+            else:
+                raise FileNotFoundError()
+        return mock_open()()
+
+    with patch("builtins.open", mock_file_open):
+        main()
+
+    mock_exit.assert_not_called()
+
+@patch("scripts.add_event.sys.exit")
+def test_main_various_validations(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    invalid_body = """
+### Event Name
+Invalid Event
+### Start Date
+2026-13-40
+### End Date
+2025-10-10
+### Start Time
+2pm
+### End Time
+13:00
+### Event URL
+www.example.com
+### Location
+New York
+### Region (Continent)
+North America
+### Language
+English
+### Featured
+2
+### Event Description (200 char max)
+""" + ("A" * 201)
+    monkeypatch.setenv("ISSUE_BODY", invalid_body)
+
+    with patch("builtins.open", mock_open()):
+        with pytest.raises(SystemExit):
+            main()
+        mock_exit.assert_called_once_with(1)
+
+@patch("scripts.add_event.sys.exit")
+def test_main_validation_date_comparisons(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    invalid_body = """
+### Event Name
+Invalid Event
+### Start Date
+2026-10-10
+### End Date
+2025-10-10
+### Start Time
+14:00
+### End Time
+13:00
+### Event URL
+https://www.example.com
+### Location
+New York
+### Region (Continent)
+North America
+### Language
+English
+"""
+    monkeypatch.setenv("ISSUE_BODY", invalid_body)
+    with patch("builtins.open", mock_open()):
+        with pytest.raises(SystemExit):
+            main()
+
+@patch("scripts.add_event.sys.exit")
+def test_main_validation_url_exception(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    invalid_body = """
+### Event Name
+Invalid Event
+### Start Date
+2026-10-10
+### Event URL
+http://[::1]:8080/
+### Location
+New York
+### Region (Continent)
+North America
+### Language
+English
+"""
+    monkeypatch.setenv("ISSUE_BODY", invalid_body)
+
+    with patch("builtins.open", mock_open()):
+        with patch("urllib.parse.urlparse", side_effect=Exception("URL Error")):
+            with pytest.raises(SystemExit):
+                main()
+
+@patch("scripts.add_event.sys.exit")
+def test_main_validation_time_comparisons(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    invalid_body = """
+### Event Name
+Invalid Event
+### Start Date
+2026-10-10
+### End Date
+2026-10-10
+### Start Time
+14:00
+### End Time
+13:00
+### Event URL
+https://www.example.com
+### Location
+New York
+### Region (Continent)
+North America
+### Language
+English
+"""
+    monkeypatch.setenv("ISSUE_BODY", invalid_body)
+    with patch("builtins.open", mock_open()):
+        with pytest.raises(SystemExit):
+            main()
+
+@patch("scripts.add_event.sys.exit")
+def test_main_validation_featured_value(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    invalid_body = """
+### Event Name
+Invalid Event
+### Start Date
+2026-10-10
+### Event URL
+https://example.com
+### Location
+New York
+### Region (Continent)
+North America
+### Language
+English
+### Featured
+2
+"""
+    monkeypatch.setenv("ISSUE_BODY", invalid_body)
+    with patch("builtins.open", mock_open()):
+        with pytest.raises(SystemExit):
+            main()
+
+@patch("scripts.add_event.sys.exit")
+def test_main_missing_events_yaml(mock_exit, monkeypatch):
+    mock_exit.side_effect = SystemExit
+    valid_body = "### Event Name\nValid Event\n### Start Date\n2026-10-10\n### Event URL\nhttps://example.com\n### Location\nNew York\n### Region (Continent)\nNorth America\n### Language\nEnglish\n"
+    monkeypatch.setenv("ISSUE_BODY", valid_body)
+
+    with patch("pathlib.Path.exists", return_value=False):
+        with pytest.raises(SystemExit):
+            main()
+
+@patch("scripts.add_event.sys.exit")
+@patch("scripts.add_event.geocode_location_forced")
+def test_main_duplicate_id(mock_geocode, mock_exit, monkeypatch):
+    valid_body = "### Event Name\nValid Event\n### Start Date\n2026-10-10\n### Event URL\nhttps://example.com\n### Location\nNew York\n### Region (Continent)\nNorth America\n### Language\nEnglish\n"
+    monkeypatch.setenv("ISSUE_BODY", valid_body)
+    mock_geocode.return_value = None
+
+    existing_yaml = "events:\n  - id: '202610101234'\n"
+
+    def mock_file_open(filename, mode="r", *args, **kwargs):
+        if "events.yaml" in str(filename):
+            if "a" in mode:
+                return mock_open()()
+            else:
+                return mock_open(read_data=existing_yaml)()
+        return mock_open()()
+
+    with patch("builtins.open", mock_file_open):
+        with patch("scripts.add_event.random.randint", side_effect=[1234, 5678]):
+            with patch("scripts.add_event.datetime") as mock_dt:
+                mock_dt.now.return_value.strftime.return_value = "20261010"
+                main()
+
+@patch("scripts.add_event.sys.exit")
+@patch("scripts.add_event.geocode_location_forced")
+def test_main_cache_write_error(mock_geocode, mock_exit, monkeypatch):
+    valid_body = "### Event Name\nValid Event\n### Start Date\n2026-10-10\n### Event URL\nhttps://example.com\n### Location\nNew York\n### Region (Continent)\nNorth America\n### Language\nEnglish\n"
+    monkeypatch.setenv("ISSUE_BODY", valid_body)
+    mock_geocode.return_value = (40.7, -74.0)
+
+    def mock_file_open(filename, mode="r", *args, **kwargs):
+        if ".geocode_cache.json" in str(filename) and "w" in mode:
+            raise PermissionError("No write access")
+        if "events.yaml" in str(filename):
+            if "a" in mode:
+                return mock_open()()
+            else:
+                return mock_open(read_data="events: []\n")()
+        return mock_open()()
+
+    with patch("builtins.open", mock_file_open):
+        main()
+
+@patch("scripts.add_event.sys.exit")
+@patch("scripts.add_event.geocode_location_forced")
+def test_main_geocoding_fallbacks(mock_geocode, mock_exit, monkeypatch):
+    valid_body = "### Event Name\nValid Event\n### Start Date\n2026-10-10\n### Event URL\nhttps://example.com\n### City\nParis\n### Country\nFrance\n### Region (Continent)\nEurope\n### Language\nEnglish\n"
+    monkeypatch.setenv("ISSUE_BODY", valid_body)
+
+    mock_geocode.side_effect = [None, None, (48.8, 2.3)]
+
+    def mock_file_open(filename, mode="r", *args, **kwargs):
+        if "events.yaml" in str(filename):
+            if "a" in mode:
+                return mock_open()()
+            else:
+                return mock_open(read_data="events: []\n")()
+        return mock_open()()
+
+    with patch("builtins.open", mock_file_open):
+        main()
+
+@patch("scripts.add_event.sys.exit")
+@patch("scripts.add_event.geocode_location_forced")
+def test_main_yaml_ending_without_newline(mock_geocode, mock_exit, monkeypatch):
+    valid_body = "### Event Name\nValid Event\n### Start Date\n2026-10-10\n### Event URL\nhttps://example.com\n### Location\nNew York\n### Region (Continent)\nNorth America\n### Language\nEnglish\n"
+    monkeypatch.setenv("ISSUE_BODY", valid_body)
+
+    mock_geocode.return_value = None
+
+    def mock_file_open(filename, mode="r", *args, **kwargs):
+        if "events.yaml" in str(filename):
+            if "a" in mode:
+                return mock_open()()
+            else:
+                return mock_open(read_data="events: []")()
+        return mock_open()()
+
+    with patch("builtins.open", mock_file_open):
+        main()
+
+def test_script_execution():
+    env = os.environ.copy()
+    env["ISSUE_BODY"] = ""
+    result = subprocess.run(["python3", "scripts/add_event.py"], env=env, capture_output=True)
+    assert result.returncode == 1

--- a/tests/test_check_dead_links.py
+++ b/tests/test_check_dead_links.py
@@ -1,0 +1,122 @@
+import sys
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+# Add scripts directory to path to import check_dead_links
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from unittest.mock import mock_open
+from check_dead_links import check_link, main
+
+@patch("check_dead_links.requests.head")
+def test_check_link_head_success(mock_head):
+    """Test function."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_head.return_value = mock_response
+
+    is_ok, reason = check_link("http://example.com")
+    assert is_ok is True
+    assert reason == "200"
+    mock_head.assert_called_once()
+
+@patch("check_dead_links.requests.get")
+@patch("check_dead_links.requests.head")
+def test_check_link_head_fails_get_succeeds(mock_head, mock_get):
+    """Test function."""
+    mock_head_response = MagicMock()
+    mock_head_response.status_code = 405  # Method not allowed for HEAD
+    mock_head.return_value = mock_head_response
+
+    mock_get_response = MagicMock()
+    mock_get_response.status_code = 200
+    mock_get.return_value = mock_get_response
+
+    is_ok, reason = check_link("http://example.com")
+    assert is_ok is True
+    assert reason == "200"
+    mock_head.assert_called_once()
+    mock_get.assert_called_once()
+
+@patch("check_dead_links.requests.head")
+def test_check_link_not_found(mock_head):
+    """Test function."""
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_head.return_value = mock_response
+
+    is_ok, reason = check_link("http://example.com")
+    assert is_ok is False
+    assert "Status Code: 404" in reason
+
+@patch("check_dead_links.requests.head")
+def test_check_link_timeout(mock_head):
+    """Test function."""
+    mock_head.side_effect = requests.exceptions.Timeout()
+
+    is_ok, reason = check_link("http://example.com")
+    assert is_ok is False
+    assert reason == "Timeout (10s)"
+
+@patch("check_dead_links.requests.head")
+def test_check_link_connection_error(mock_head):
+    """Test function."""
+    mock_head.side_effect = requests.exceptions.ConnectionError()
+
+    is_ok, reason = check_link("http://example.com")
+    assert is_ok is False
+    assert reason == "Connection Error"
+
+@patch("check_dead_links.requests.head")
+def test_check_link_request_exception(mock_head):
+    """Test function."""
+    mock_head.side_effect = requests.exceptions.RequestException("Some error")
+
+    is_ok, reason = check_link("http://example.com")
+    assert is_ok is False
+    assert "Request Error: Some error" in reason
+
+@patch("check_dead_links.INPUT_FILE")
+@patch("check_dead_links.sys.exit")
+@patch("builtins.open", new_callable=mock_open, read_data="events:\n  - id: '1'\n    url: 'http://broken.com'\n")
+@patch("check_dead_links.check_link")
+def test_main_generates_report(mock_check_link, mock_open_file, mock_exit, mock_input_file):
+    """Test function."""
+    mock_input_file.exists.return_value = True
+    mock_check_link.return_value = (False, "404 Not Found")
+
+    main()
+
+    mock_exit.assert_called_once_with(1)
+
+    # Check if write was called with the report
+    written_content = "".join(call.args[0] for call in mock_open_file().write.call_args_list)
+    assert "http://broken.com" in written_content
+    assert "404 Not Found" in written_content
+
+@patch("check_dead_links.INPUT_FILE")
+@patch("builtins.open", new_callable=mock_open, read_data="events: []\n")
+def test_main_no_events(mock_open_file, mock_input_file, capsys):
+    """Test function."""
+    mock_input_file.exists.return_value = True
+    main()
+    captured = capsys.readouterr()
+    assert "No events found to check." in captured.out
+
+@patch("check_dead_links.REPORT_FILE")
+@patch("check_dead_links.INPUT_FILE")
+@patch("check_dead_links.sys.exit")
+@patch("builtins.open", new_callable=mock_open, read_data="events:\n  - id: '1'\n    url: 'http://healthy.com'\n")
+@patch("check_dead_links.check_link")
+def test_main_all_healthy(mock_check_link, mock_open_file, mock_exit, mock_input_file, mock_report_file):
+    """Test function."""
+    mock_input_file.exists.return_value = True
+    mock_check_link.return_value = (True, "200")
+    mock_report_file.exists.return_value = True # ensure we test unlink
+
+    main()
+
+    mock_exit.assert_called_once_with(0)
+    mock_report_file.unlink.assert_called_once()

--- a/tests/test_generate_events_json.py
+++ b/tests/test_generate_events_json.py
@@ -41,10 +41,10 @@ def test_validate_event_missing_fields():
     event = {
         "id": "1",
         "title": "Test Event",
-        # missing description, date, location, region, category
+        # missing description, date, location, region
     }
     errors = validate_event(event, 1)
-    assert len(errors) == 5
+    assert len(errors) == 4
     assert any("Missing required field 'description'" in e for e in errors)
 
 def test_validate_event_invalid_date():

--- a/tests/test_generate_events_json.py
+++ b/tests/test_generate_events_json.py
@@ -1,0 +1,159 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+# Add scripts directory to path to import generate_events_json
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from unittest.mock import mock_open
+from generate_events_json import is_ci, validate_event, geocode_location, update_yaml_surgically
+
+def test_is_ci(monkeypatch):
+    """Test function."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("NETLIFY", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("VERCEL", raising=False)
+    assert is_ci() is False
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert is_ci() is True
+
+def test_validate_event_valid():
+    """Test function."""
+    event = {
+        "id": "1",
+        "title": "Test Event",
+        "description": "Desc",
+        "date": "2023-10-15",
+        "time": "14:00",
+        "location": "Online",
+        "region": "Global",
+        "category": "Tech"
+    }
+    errors = validate_event(event, 1)
+    assert errors == []
+
+def test_validate_event_missing_fields():
+    """Test function."""
+    event = {
+        "id": "1",
+        "title": "Test Event",
+        # missing description, date, location, region, category
+    }
+    errors = validate_event(event, 1)
+    assert len(errors) == 5
+    assert any("Missing required field 'description'" in e for e in errors)
+
+def test_validate_event_invalid_date():
+    """Test function."""
+    event = {
+        "id": "1",
+        "title": "Test Event",
+        "description": "Desc",
+        "date": "15-10-2023", # Invalid format
+        "location": "Online",
+        "region": "Global",
+        "category": "Tech"
+    }
+    errors = validate_event(event, 1)
+    assert len(errors) == 1
+    assert "Invalid date format" in errors[0]
+
+def test_validate_event_invalid_time():
+    """Test function."""
+    event = {
+        "id": "1",
+        "title": "Test Event",
+        "description": "Desc",
+        "date": "2023-10-15",
+        "time": "2pm", # Invalid format
+        "location": "Online",
+        "region": "Global",
+        "category": "Tech"
+    }
+    errors = validate_event(event, 1)
+    assert len(errors) == 1
+    assert "Invalid time format" in errors[0]
+
+def test_validate_event_python_datetime_objects():
+    """Test function."""
+    import datetime
+    event = {
+        "id": "1",
+        "title": "Test Event",
+        "description": "Desc",
+        "date": datetime.date(2023, 10, 15),
+        "time": datetime.time(14, 0),
+        "location": "Online",
+        "region": "Global",
+        "category": "Tech"
+    }
+    errors = validate_event(event, 1)
+    assert len(errors) == 0
+    # The script converts time objects to strings, but leaves datetime.date objects as-is
+    assert str(event["date"]) == "2023-10-15"
+    assert event["time"] == "14:00"
+
+@patch("generate_events_json.INPUT_FILE")
+def test_update_yaml_surgically_file_not_found(mock_input_file):
+    """Test function."""
+    mock_input_file.exists.return_value = False
+    update_yaml_surgically([{"id": "1", "lat": 12.3, "lng": 45.6}])
+
+@patch("generate_events_json.is_ci")
+@patch("generate_events_json.get_cache")
+def test_geocode_location_online(mock_get_cache, mock_is_ci):
+    """Test function."""
+    assert geocode_location("Online") is None
+    assert geocode_location("online") is None
+    assert geocode_location("") is None
+
+@patch("generate_events_json.is_ci")
+@patch("generate_events_json.get_cache")
+def test_geocode_location_cached(mock_get_cache, mock_is_ci):
+    """Test function."""
+    mock_get_cache.return_value = {"London": (51.5074, -0.1278)}
+    assert geocode_location("London") == (51.5074, -0.1278)
+
+@patch("generate_events_json.is_ci")
+@patch("generate_events_json.get_cache")
+def test_geocode_location_ci_skip(mock_get_cache, mock_is_ci):
+    """Test function."""
+    mock_get_cache.return_value = {}
+    mock_is_ci.return_value = True
+    assert geocode_location("Paris") is None
+
+@patch("generate_events_json.urllib.request.urlopen")
+@patch("generate_events_json.is_ci")
+@patch("generate_events_json.get_cache")
+@patch("generate_events_json.time.sleep")
+def test_geocode_location_network_success(mock_sleep, mock_get_cache, mock_is_ci, mock_urlopen):
+    """Test function."""
+    mock_get_cache.return_value = {}
+    mock_is_ci.return_value = False
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'[{"lat": "48.8566", "lon": "2.3522"}]'
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    result = geocode_location("Paris")
+    assert mock_get_cache.return_value["Paris"] == (48.8566, 2.3522)
+
+@patch("generate_events_json.INPUT_FILE")
+@patch("builtins.open", new_callable=mock_open, read_data="events:\n  - id: '1'\n    title: 'Test'\n")
+def test_update_yaml_surgically(mock_file, mock_input_file):
+    """Test function."""
+    mock_input_file.exists.return_value = True
+    events_with_coords = [{"id": "1", "lat": 12.34, "lng": 56.78}]
+    update_yaml_surgically(events_with_coords)
+
+    # Check if writelines was called
+    assert mock_file().writelines.called
+    lines_written = mock_file().writelines.call_args[0][0]
+    written_data = "".join(lines_written)
+
+    assert "lat: 12.34" in written_data
+    assert "lng: 56.78" in written_data

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,5 +20,9 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: "./src/test/setup.js",
+    coverage: {
+      reporter: ["text", "json-summary", "json"],
+      reportOnFailure: true,
+    },
   },
 });


### PR DESCRIPTION
**Frontend Testing (React/Vitest):** Added 50 unit tests covering core interactive components including EventCard, SearchBar, EventDetails, SearchableSelect, and the internal eventHelpers.js logic.
**Backend Testing (Python/Pytest):** Added 21 unit tests covering the generate_events_json.py and check_dead_links.py scripts. These tests simulate broken data, invalid URLs, and file writing to ensure our data pipeline never corrupts events.json.
**CI/CD Pipeline Upgrades:**
Modified .github/workflows/ci.yaml to include a dedicated test-backend job that runs the Pytest suite.
Added the davelosert/vitest-coverage-report-action so GitHub will automatically calculate test coverage and post it as a comment directly on PRs!
**Pre-commit Hooks:** Fixed the douki linter scope to properly ignore tests, and added a local pytest hook so developers catch backend bugs before committing.

**How to test this locally:**
1. Test the Frontend (React) To run the Vitest suite and generate the new coverage report table:
`npm run test:coverage`
<img width="952" height="676" alt="image" src="https://github.com/user-attachments/assets/138f8b3f-018d-4884-ae06-4e6f10a52900" />

2. Test the Backend (Python) Ensure you have the testing tools installed (pip install pytest pytest-mock pytest-cov), then run:
`python3 -m pytest tests/`
<img width="918" height="180" alt="image" src="https://github.com/user-attachments/assets/7025a199-db4a-4e74-af49-449c8b8b1e45" />

3. Test the Pre-commit hook To ensure the automated formatting and testing hooks work perfectly across the entire project before a commit:
`pre-commit run --all-files`
